### PR TITLE
feat: Filter read-write sets during endorsement

### DIFF
--- a/core/endorser/endorser.go
+++ b/core/endorser/endorser.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/common/validation"
 	"github.com/hyperledger/fabric/core/ledger"
+	xendorser "github.com/hyperledger/fabric/extensions/endorser"
 	"github.com/hyperledger/fabric/internal/pkg/identity"
 	"github.com/hyperledger/fabric/protos/common"
 	pb "github.com/hyperledger/fabric/protos/peer"
@@ -265,6 +266,7 @@ func (e *Endorser) SimulateProposal(txParams *ccprovider.TransactionParams, cid 
 			return nil, nil, nil, nil, err
 		}
 
+		var collConfigs map[string]*common.CollectionConfigPackage
 		if simResult.PvtSimulationResults != nil {
 			if cid.Name == "lscc" {
 				// TODO: remove once we can store collection configuration outside of LSCC
@@ -292,10 +294,15 @@ func (e *Endorser) SimulateProposal(txParams *ccprovider.TransactionParams, cid 
 			if err := e.distributePrivateData(txParams.ChannelID, txParams.TxID, pvtDataWithConfig, endorsedAt); err != nil {
 				return nil, nil, nil, nil, err
 			}
+			collConfigs = pvtDataWithConfig.CollectionConfigs
 		}
 
 		txParams.TXSimulator.Done()
-		if pubSimResBytes, err = simResult.GetPubSimulationBytes(); err != nil {
+		pubSimRes, err := xendorser.FilterPubSimulationResults(collConfigs, simResult.PubSimulationResults)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		if pubSimResBytes, err = proto.Marshal(pubSimRes); err != nil {
 			return nil, nil, nil, nil, err
 		}
 	}

--- a/extensions/endorser/endorser.go
+++ b/extensions/endorser/endorser.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorser
+
+import (
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset"
+)
+
+// FilterPubSimulationResults filters the public simulation results and returns the filtered results or error.
+// The default implementation does not perform any filtering.
+func FilterPubSimulationResults(_ map[string]*common.CollectionConfigPackage, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
+	return pubSimulationResults, nil
+}

--- a/extensions/endorser/endorser_test.go
+++ b/extensions/endorser/endorser_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorser
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterPubSimulationResults(t *testing.T) {
+	pubSimulationResults := &rwset.TxReadWriteSet{}
+	p, err := FilterPubSimulationResults(map[string]*common.CollectionConfigPackage{}, pubSimulationResults)
+	assert.NoError(t, err)
+	assert.Equal(t, pubSimulationResults, p)
+}


### PR DESCRIPTION
Add an extension point which allows for filtering of read-write
sets before they are endorsed and sent to the orderer.

closes #54 

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>