### PR TITLE
fix: Use CollStoreProvider interface instead of struct

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -96,12 +96,13 @@ type chainSupport struct {
 
 var TransientStoreFactory = &storeProvider{stores: make(map[string]transientstore.Store)}
 
-var collectionDataStoreFactory *storeprovider.StoreProvider
+var collectionDataStoreFactory CollStoreProvider
 var initCollDataStoreFactoryOnce sync.Once
 
+// CollStoreProvider manages the collection stores for multiple channels
 type CollStoreProvider interface {
-	StoreForChannel(channel string) storeapi.Store
-	OpenStore(ledgerID string) (storeapi.Store, error)
+	StoreForChannel(channelID string) storeapi.Store
+	OpenStore(channelID string) (storeapi.Store, error)
 }
 
 // CollectionDataStoreFactory returns transient data stores by channel ID


### PR DESCRIPTION
The collection store provider variable in peer.go should be using the
interface CollStoreProvider instead of the StoreProvider struct.

closes #59

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>