### PR TITLE
feat: Add hook to State CouchDB cleanup function

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test_export.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test_export.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger/fabric/common/metrics/disabled"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/ledgerconfig"
+	"github.com/hyperledger/fabric/extensions/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,6 +49,10 @@ func (env *TestVDBEnv) Cleanup() {
 }
 
 func CleanupDB(t testing.TB, dbProvider statedb.VersionedDBProvider) {
+	if extDbProvider := testutil.GetExtStateDBProvider(t, dbProvider); extDbProvider != nil {
+		dbProvider = extDbProvider
+	}
+
 	couchdbProvider, _ := dbProvider.(*VersionedDBProvider)
 	for _, v := range couchdbProvider.databases {
 		if _, err := v.metadataDB.DropDatabase(); err != nil {

--- a/extensions/testutil/ext_test_env.go
+++ b/extensions/testutil/ext_test_env.go
@@ -6,6 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package testutil
 
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+)
+
 //SetupExtTestEnv creates new extension test environment,
 // it creates couchdb instance for test, returns couchdbd address, cleanup and destroy function handle.
 func SetupExtTestEnv() (addr string, cleanup func(string), stop func()) {
@@ -14,4 +20,8 @@ func SetupExtTestEnv() (addr string, cleanup func(string), stop func()) {
 		}, func() {
 			//do nothing
 		}
+}
+
+func GetExtStateDBProvider(t testing.TB, dbProvider statedb.VersionedDBProvider) statedb.VersionedDBProvider {
+	return nil
 }


### PR DESCRIPTION
The couchDB test clean up function 'casts' DBProvider to CouchDBProvider. This limits the ability to wrap this in other DBProviders. This new extension gets the couchDB wrapped in other VersionedDBProvider.

Closes #63

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>