### PR TITLE
chore: Add fabric-peer-ext CouchDB hooks

### DIFF
--- a/core/ledger/kvledger/custom_processor_test.go
+++ b/core/ledger/kvledger/custom_processor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/customtx"
 	lgrutil "github.com/hyperledger/fabric/core/ledger/util"
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric/protos/peer"
@@ -39,6 +40,9 @@ func (ctp *customTxProcessor) GenerateSimulationResults(txEnvelop *common.Envelo
 }
 
 func TestCustomProcessor(t *testing.T) {
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	conf, cleanup := testConfig(t)
 	defer cleanup()
 	provider := testutilNewProvider(conf, t)

--- a/core/ledger/kvledger/hashcheck_pvtdata_test.go
+++ b/core/ledger/kvledger/hashcheck_pvtdata_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/fabric/common/ledger/testutil"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,9 @@ import (
 func TestConstructValidInvalidBlocksPvtData(t *testing.T) {
 	conf, cleanup := testConfig(t)
 	defer cleanup()
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	provider := testutilNewProvider(conf, t)
 	defer provider.Close()
 

--- a/core/ledger/kvledger/kv_ledger_provider_test.go
+++ b/core/ledger/kvledger/kv_ledger_provider_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/fabric/common/util"
 	lgr "github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/mock"
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/queryresult"
 	"github.com/hyperledger/fabric/protoutil"
@@ -276,6 +277,9 @@ func TestMultipleLedgerBasicRW(t *testing.T) {
 }
 
 func TestLedgerBackup(t *testing.T) {
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	ledgerid := "TestLedger"
 	basePath, err := ioutil.TempDir("", "kvledger")
 	if err != nil {
@@ -445,8 +449,11 @@ func testConfig(t *testing.T) (conf *lgr.Config, cleanup func()) {
 			Enabled: true,
 		},
 	}
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
 	cleanup = func() {
 		os.RemoveAll(path)
+		destroy()
 	}
 
 	return conf, cleanup

--- a/core/ledger/kvledger/tests/rebuild_test.go
+++ b/core/ledger/kvledger/tests/rebuild_test.go
@@ -50,7 +50,7 @@ func TestRebuildComponents(t *testing.T) {
 		func(t *testing.T) {
 
 			flag := rebuildableStatedb + rebuildableBlockIndex
-			_, err := util.DirEmpty(filepath.Join(env.rootPath, "ledgersData", "stateLeveldb"))
+			_, err := util.DirEmpty(filepath.Join(env.rootPath, "ledgersData", "chains"))
 			if err != nil && strings.Contains(err.Error(), "no such file or directory") {
 				//couch db index, no need to attempt to delete index file
 				flag = rebuildableStatedb

--- a/core/ledger/ledgermgmt/ledger_mgmt_test.go
+++ b/core/ledger/ledgermgmt/ledger_mgmt_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/cceventmgmt"
 	"github.com/hyperledger/fabric/core/ledger/mock"
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,6 +56,9 @@ func TestLedgerMgmt(t *testing.T) {
 		},
 	}
 
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	cleanup, err := InitializeTestEnvWithInitializer(initializer)
 	if err != nil {
 		t.Fatalf("Failed to initialize test environment: %s", err)
@@ -99,6 +103,9 @@ func TestLedgerMgmt(t *testing.T) {
 }
 
 func TestChaincodeInfoProvider(t *testing.T) {
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	cleanup := InitializeTestEnv(t)
 	defer cleanup()
 	gb, _ := test.MakeGenesisBlock("ledger1")

--- a/core/ledger/ledgerstorage/store_test.go
+++ b/core/ledger/ledgerstorage/store_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/pvtdatastorage"
 	lutil "github.com/hyperledger/fabric/core/ledger/util"
 	blkstorageext "github.com/hyperledger/fabric/extensions/blkstorage"
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	pb "github.com/hyperledger/fabric/protos/peer"
@@ -30,6 +31,7 @@ import (
 
 func TestMain(m *testing.M) {
 	flogging.ActivateSpec("ledgerstorage,pvtdatastorage=debug")
+
 	os.Exit(m.Run())
 }
 
@@ -39,6 +41,9 @@ func TestStore(t *testing.T) {
 		t.Fatalf("Failed to create ledger storage directory: %s", err)
 	}
 	defer os.RemoveAll(storeDir)
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	conf := &ledger.PrivateData{
 		StorePath:     filepath.Join(storeDir, "pvtdataStore"),
 		PurgeInterval: 1,
@@ -120,6 +125,9 @@ func TestStoreWithExistingBlockchain(t *testing.T) {
 		t.Fatalf("Failed to create ledger storage directory: %s", err)
 	}
 	defer os.RemoveAll(storeDir)
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 
 	// Construct a block storage
 	attrsToIndex := []blkstorage.IndexableAttr{
@@ -179,6 +187,9 @@ func TestCrashAfterPvtdataStorePreparation(t *testing.T) {
 		t.Fatalf("Failed to create ledger storage directory: %s", err)
 	}
 	defer os.RemoveAll(storeDir)
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	conf := &ledger.PrivateData{
 		StorePath:     filepath.Join(storeDir, "pvtdataStore"),
 		PurgeInterval: 1,
@@ -241,6 +252,9 @@ func TestCrashBeforePvtdataStoreCommit(t *testing.T) {
 		t.Fatalf("Failed to create ledger storage directory: %s", err)
 	}
 	defer os.RemoveAll(storeDir)
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	conf := &ledger.PrivateData{
 		StorePath:     filepath.Join(storeDir, "pvtdataStore"),
 		PurgeInterval: 1,
@@ -287,6 +301,9 @@ func TestAddAfterPvtdataStoreError(t *testing.T) {
 		t.Fatalf("Failed to create ledger storage directory: %s", err)
 	}
 	defer os.RemoveAll(storeDir)
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	conf := &ledger.PrivateData{
 		StorePath:     filepath.Join(storeDir, "pvtdataStore"),
 		PurgeInterval: 1,
@@ -331,6 +348,9 @@ func TestAddAfterBlkStoreError(t *testing.T) {
 		t.Fatalf("Failed to create ledger storage directory: %s", err)
 	}
 	defer os.RemoveAll(storeDir)
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 	conf := &ledger.PrivateData{
 		StorePath:     filepath.Join(storeDir, "pvtdataStore"),
 		PurgeInterval: 1,

--- a/internal/peer/node/start_test.go
+++ b/internal/peer/node/start_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric/common/viperutil"
 	"github.com/hyperledger/fabric/core/handlers/library"
 	"github.com/hyperledger/fabric/core/testutil"
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
@@ -30,6 +31,9 @@ func TestStartCmd(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "startcmd")
 	g.Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(tempDir)
+	//setup extension test environment
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 
 	viper.Set("peer.address", "localhost:6051")
 	viper.Set("peer.listenAddress", "0.0.0.0:6051")

--- a/peer/node/main_test.go
+++ b/peer/node/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"testing"
 
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,8 @@ import (
 
 func TestStart(t *testing.T) {
 	defer viper.Reset()
+	_, _, destroy := xtestutil.SetupExtTestEnv()
+	defer destroy()
 
 	tempDir, err := ioutil.TempDir("", "startcmd")
 	require.NoError(t, err)


### PR DESCRIPTION
Add fabric-peer-ext CouchDB hooks which were purged during #70 (files were deleted in fabric which had the hooks).

Closes #74

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>