### PR TITLE
docs: Fabric-mod Documentation broken link fix

### DIFF
--- a/docs/source/gobackextension.rst
+++ b/docs/source/gobackextension.rst
@@ -1,4 +1,0 @@
-Go Back To Extension
-====================
-
-`Extension points for Hyperledger Fabric <../../../extensions/docs/build/html/index.html>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,6 @@ modularity and versatility for a broad set of industry use cases.
    releases
    questions
    status
-   gobackextension
 
 .. note:: If you have questions not addressed by this documentation, or run into
           issues with any of the tutorials, please visit the :doc:`questions`

--- a/extensions/docs/source/hyperledgerfabric.rst
+++ b/extensions/docs/source/hyperledgerfabric.rst
@@ -1,4 +1,0 @@
-Hyperledger Fabric
-==================
-
-View referenced `Hyperledger Fabric Documentation <../../../../docs/build/html/index.html>`_.

--- a/extensions/docs/source/index.rst
+++ b/extensions/docs/source/index.rst
@@ -13,7 +13,7 @@ Compile time Extension Points for Hyperledger Fabric by leveraging `Go Modules <
    extension
    Contribution <https://github.com/trustbloc/community/blob/master/CONTRIBUTING.md>
    questions
-   hyperledgerfabric
+   Hyperledger Fabric <https://hyperledger-fabric.readthedocs.io/en/latest/>
 
 
 .. note:: If you have questions not addressed by this documentation, or run into

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: extensions/docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs


### PR DESCRIPTION
- Readthedocs.yml customize the conf.py file path to extensions/docs/source
  This will point fabric-mod to extension doc.
- Instead of cross referencing and host hyperledger documentation on trustblco
  It makes more sense to hyperlink the supported version of hyperledger documentation.
Closes: #75
Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>