### PR TITLE
test: CouchDB Ext UnitTest - Update MaxRetries count

### DIFF
--- a/core/ledger/util/couchdb/couchdb_ext_test.go
+++ b/core/ledger/util/couchdb/couchdb_ext_test.go
@@ -85,8 +85,11 @@ func TestIndexDesignDocExistsWithRetry(t *testing.T) {
 	require.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
 	defer cleanup(database)
 
+	config := testConfig()
+	config.MaxRetries = 5
+
 	//create a new instance and database object
-	couchInstance, err := CreateCouchInstance(testConfig(), &disabled.Provider{})
+	couchInstance, err := CreateCouchInstance(config, &disabled.Provider{})
 	require.NoError(t, err, "Error when trying to create couch instance")
 	db := CouchDatabase{CouchInstance: couchInstance, DBName: database}
 
@@ -144,8 +147,11 @@ func TestDBExistsWithRetry(t *testing.T) {
 	require.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
 	defer cleanup(database)
 
+	config := testConfig()
+	config.MaxRetries = 5
+
 	//create a new instance and database object
-	couchInstance, err := CreateCouchInstance(testConfig(), &disabled.Provider{})
+	couchInstance, err := CreateCouchInstance(config, &disabled.Provider{})
 	require.NoError(t, err, "Error when trying to create couch instance")
 	db := CouchDatabase{CouchInstance: couchInstance, DBName: database}
 


### PR DESCRIPTION
The original value of MaxRetries count was specifically set to 5 in CouchDBExt retry test cases https://github.com/trustbloc/fabric-mod/commit/dbf261c87eea5555d7c015bb843c2107f28f1b9c#diff-e4247e115c4f9b9eb3723c86acb39b70R153. The latest fabric has new design for CouchDB configuration and this change was lost during merge process.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>