### PR TITLE
feat: Expose peer InitCmd function and CmdRoot const

### DIFF
--- a/peer/node/common.go
+++ b/peer/node/common.go
@@ -1,0 +1,19 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package node
+
+import (
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/spf13/cobra"
+)
+
+const CmdRoot = common.CmdRoot
+
+// InitCmd initiated the fabric peer
+func InitCmd(cmd *cobra.Command, args []string) {
+	common.InitCmd(cmd, args)
+}

--- a/peer/node/common_test.go
+++ b/peer/node/common_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package node
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/config/configtest"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCmd(t *testing.T) {
+	cleanup := configtest.SetDevFabricConfigPath(t)
+	defer cleanup()
+	defer viper.Reset()
+
+	// test that InitCmd doesn't remove existing loggers from the logger levels map
+	flogging.MustGetLogger("test")
+	flogging.ActivateSpec("test=error")
+	assert.Equal(t, "error", flogging.Global.Level("test").String())
+	flogging.MustGetLogger("chaincode")
+	assert.Equal(t, flogging.Global.DefaultLevel().String(), flogging.Global.Level("chaincode").String())
+	flogging.MustGetLogger("test.test2")
+	flogging.ActivateSpec("test.test2=warn")
+	assert.Equal(t, "warn", flogging.Global.Level("test.test2").String())
+
+	origEnvValue := os.Getenv("FABRIC_LOGGING_SPEC")
+	os.Setenv("FABRIC_LOGGING_SPEC", "chaincode=debug:test.test2=fatal:abc=error")
+	common.InitCmd(nil, nil)
+	assert.Equal(t, "debug", flogging.Global.Level("chaincode").String())
+	assert.Equal(t, "info", flogging.Global.Level("test").String())
+	assert.Equal(t, "fatal", flogging.Global.Level("test.test2").String())
+	assert.Equal(t, "error", flogging.Global.Level("abc").String())
+	os.Setenv("FABRIC_LOGGING_SPEC", origEnvValue)
+}


### PR DESCRIPTION
As part of HL fabric restructure, the peer code was moved inside internal folder and is not accessible from other modules. Bloc-node uses these functions to initialize the peer. Exposed the function and constant through new pacakage.

Implements #82

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>