### PR TITLE
feat: Add support for off-ledger and DCAS in config parser

### DIFF
--- a/internal/peer/chaincode/common.go
+++ b/internal/peer/chaincode/common.go
@@ -184,6 +184,8 @@ type CollectionType string
 const (
 	CollectionType_PRIVATE   CollectionType = "PRIVATE"
 	CollectionType_TRANSIENT CollectionType = "TRANSIENT"
+	CollectionType_OFFLEDGER CollectionType = "OFFLEDGER"
+	CollectionType_DCAS      CollectionType = "DCAS"
 )
 
 type collectionConfigJson struct {
@@ -247,6 +249,36 @@ func getCollectionConfigFromBytes(cconfBytes []byte) (*pcommon.CollectionConfigP
 						MemberOnlyRead:    cconfitem.MemberOnlyRead,
 						MemberOnlyWrite:   cconfitem.MemberOnlyWrite,
 						Type:              pcommon.CollectionType_COL_TRANSIENT,
+						TimeToLive:        cconfitem.TimeToLive,
+					},
+				},
+			}
+		case CollectionType_OFFLEDGER:
+			cc = &pcommon.CollectionConfig{
+				Payload: &pcommon.CollectionConfig_StaticCollectionConfig{
+					StaticCollectionConfig: &pcommon.StaticCollectionConfig{
+						Name:              cconfitem.Name,
+						MemberOrgsPolicy:  cpc,
+						RequiredPeerCount: cconfitem.RequiredCount,
+						MaximumPeerCount:  cconfitem.MaxPeerCount,
+						MemberOnlyRead:    cconfitem.MemberOnlyRead,
+						MemberOnlyWrite:   cconfitem.MemberOnlyWrite,
+						Type:              pcommon.CollectionType_COL_OFFLEDGER,
+						TimeToLive:        cconfitem.TimeToLive,
+					},
+				},
+			}
+		case CollectionType_DCAS:
+			cc = &pcommon.CollectionConfig{
+				Payload: &pcommon.CollectionConfig_StaticCollectionConfig{
+					StaticCollectionConfig: &pcommon.StaticCollectionConfig{
+						Name:              cconfitem.Name,
+						MemberOrgsPolicy:  cpc,
+						RequiredPeerCount: cconfitem.RequiredCount,
+						MaximumPeerCount:  cconfitem.MaxPeerCount,
+						MemberOnlyRead:    cconfitem.MemberOnlyRead,
+						MemberOnlyWrite:   cconfitem.MemberOnlyWrite,
+						Type:              pcommon.CollectionType_COL_DCAS,
 						TimeToLive:        cconfitem.TimeToLive,
 					},
 				},

--- a/internal/peer/chaincode/offledgercollconfig_test.go
+++ b/internal/peer/chaincode/offledgercollconfig_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright Digital Asset Holdings, LLC. All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/common/cauthdsl"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleCollectionConfigOffLedger = `[
+	{
+		"name": "foo",
+		"policy": "OR('A.member', 'B.member')",
+		"requiredPeerCount": 3,
+		"maxPeerCount": 5,
+		"type": "OFFLEDGER",
+		"timeToLive": "2m"
+	}
+]`
+
+const sampleCollectionConfigDCAS = `[
+	{
+		"name": "foo",
+		"policy": "OR('A.member', 'B.member')",
+		"requiredPeerCount": 3,
+		"maxPeerCount": 5,
+		"type": "DCAS",
+		"timeToLive": "2m"
+	}
+]`
+
+func TestOffLedgerCollectionTypeParsing(t *testing.T) {
+	pol, _ := cauthdsl.FromString("OR('A.member', 'B.member')")
+
+	t.Run("OffLedger Collection Config", func(t *testing.T) {
+		ccp, _, err := getCollectionConfigFromBytes([]byte(sampleCollectionConfigOffLedger))
+		require.NoError(t, err)
+		require.NotNil(t, ccp)
+		conf := ccp.Config[0].GetStaticCollectionConfig()
+		require.NotNil(t, conf)
+		require.Equal(t, "foo", conf.Name)
+		require.Equal(t, int32(3), conf.RequiredPeerCount)
+		require.Equal(t, int32(5), conf.MaximumPeerCount)
+		require.True(t, proto.Equal(pol, conf.MemberOrgsPolicy.GetSignaturePolicy()))
+		require.Equal(t, "2m", conf.TimeToLive)
+	})
+
+	t.Run("DCAS Collection Config", func(t *testing.T) {
+		ccp, _, err := getCollectionConfigFromBytes([]byte(sampleCollectionConfigDCAS))
+		require.NoError(t, err)
+		require.NotNil(t, ccp)
+		conf := ccp.Config[0].GetStaticCollectionConfig()
+		require.NotNil(t, conf)
+		require.Equal(t, "foo", conf.Name)
+		require.Equal(t, int32(3), conf.RequiredPeerCount)
+		require.Equal(t, int32(5), conf.MaximumPeerCount)
+		require.True(t, proto.Equal(pol, conf.MemberOrgsPolicy.GetSignaturePolicy()))
+		require.Equal(t, "2m", conf.TimeToLive)
+	})
+}


### PR DESCRIPTION
Add support for DCAS and OFFLEDGER collection types in the JSON collection config used by the peer binary when instantiating a chain code.

closes #92

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>