### PR TITLE
refactor: fixing package names

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"sync"
 
-	xpeer "github.com/hyperledger/fabric/extensions/peer"
+	xchannel "github.com/hyperledger/fabric/extensions/channel"
 
 	xstate "github.com/hyperledger/fabric/extensions/gossip/state"
 
@@ -301,7 +301,7 @@ func Initialize(
 	}
 
 	//register channel initializer
-	xpeer.RegisterChannelInitializer(getCurrConfigBlockFromLedger, createChain)
+	xchannel.RegisterChannelInitializer(pm, createChain)
 }
 
 // InitChain takes care to initialize chain after peer joined, for example deploys system CCs

--- a/core/scc/cscc/configure.go
+++ b/core/scc/cscc/configure.go
@@ -14,7 +14,7 @@ package cscc
 import (
 	"fmt"
 
-	xpeer "github.com/hyperledger/fabric/extensions/peer"
+	xchannel "github.com/hyperledger/fabric/extensions/channel"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/channelconfig"
@@ -170,7 +170,7 @@ func (e *PeerConfiger) InvokeNoShim(args [][]byte, sp *pb.SignedProposal) pb.Res
 			block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = txsFilter
 		}
 
-		return xpeer.JoinChainHandler(joinChain)(cid, block, e.sccp, e.deployedCCInfoProvider, e.legacyLifecycle, e.newLifecycle)
+		return xchannel.JoinChainHandler(joinChain)(cid, block, e.sccp, e.deployedCCInfoProvider, e.legacyLifecycle, e.newLifecycle)
 	case GetConfigBlock:
 		// 2. check policy
 		if err = e.aclProvider.CheckACL(resources.Cscc_GetConfigBlock, string(args[1]), sp); err != nil {

--- a/extensions/channel/channel.go
+++ b/extensions/channel/channel.go
@@ -25,7 +25,7 @@ func JoinChainHandler(handle JoinChain) JoinChain {
 	return handle
 }
 
-//RegisterChannelInitializer registers channel initializer using get block handle and create chain handle
-func RegisterChannelInitializer(func(ledger ledger.PeerLedger) (*common.Block, error), CreateChain) {
+//RegisterChannelInitializer registers channel initializer using given plugin mapper and create chain handle
+func RegisterChannelInitializer(plugin.Mapper, CreateChain) {
 	//do nothing
 }

--- a/extensions/channel/channel_test.go
+++ b/extensions/channel/channel_test.go
@@ -20,13 +20,13 @@ import (
 
 func TestJoinChainHandler(t *testing.T) {
 
-	sampelResponse := pb.Response{Message: "sample-test-msg"}
+	sampleResponse := pb.Response{Message: "sample-test-msg"}
 	handle := func(string, *common.Block, sysccprovider.SystemChaincodeProvider,
 		ledger.DeployedChaincodeInfoProvider, plugindispatcher.LifecycleResources, plugindispatcher.CollectionAndLifecycleResources) pb.Response {
-		return sampelResponse
+		return sampleResponse
 	}
 
 	response := JoinChainHandler(handle)("", nil, nil, nil, nil, nil)
-	require.Equal(t, sampelResponse, response)
+	require.Equal(t, sampleResponse, response)
 
 }


### PR DESCRIPTION
- package name for `extensions/peer` changed to 'extensions/channel'
- RegisterChannelInitializer function signature changed

Reason: extension for above package in fabric-peer-ext will look like
'mod/peer/peer' if we go with old name. And, ChannelInitializer in extension
doesn't need handle to get current config block from ledger since it already has one.
related to #96

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>