### PR TITLE
refactor: Init chain handle for channel initializer extensions

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -82,7 +82,7 @@ func newKVLedger(
 	}
 
 	//Recover both state DB and history DB if they are out of sync with block storage
-	if err := xrecover.RecoverDBHandler(l.recoverDBs)(); err != nil {
+	if err := xrecover.DBRecoveryHandler(l.recoverDBs)(); err != nil {
 		panic(errors.WithMessage(err, "error during state DB recovery"))
 	}
 	l.configHistoryRetriever = configHistoryMgr.GetRetriever(ledgerID, l)

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -153,7 +153,7 @@ func newVersionedDB(couchInstance *couchdb.CouchInstance, redoLogger *redoLogger
 	chainName := dbName
 	dbName = couchdb.ConstructMetadataDBName(dbName)
 
-	metadataDB, err := xcouchdb.CreateCouchDatabase(couchdb.CreateCouchDatabase)(couchInstance, dbName)
+	metadataDB, err := xcouchdb.HandleCreateCouchDatabase(couchdb.CreateCouchDatabase)(couchInstance, dbName)
 	if err != nil {
 		return nil, err
 	}

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -300,8 +300,8 @@ func Initialize(
 		InitChain(cid)
 	}
 
-	//register channel initializer
-	xchannel.RegisterChannelInitializer(pm, createChain)
+	//register channel initializer with create chain and init chain handlers
+	xchannel.RegisterChannelInitializer(pm, createChain, InitChain)
 }
 
 // InitChain takes care to initialize chain after peer joined, for example deploys system CCs

--- a/extensions/channel/channel.go
+++ b/extensions/channel/channel.go
@@ -20,12 +20,14 @@ type JoinChain func(string, *common.Block, sysccprovider.SystemChaincodeProvider
 type CreateChain func(string, ledger.PeerLedger, *common.Block, sysccprovider.SystemChaincodeProvider, plugin.Mapper,
 	ledger.DeployedChaincodeInfoProvider, plugindispatcher.LifecycleResources, plugindispatcher.CollectionAndLifecycleResources) error
 
+type InitChain func(string)
+
 //JoinChainHandler can be used to provide extended features to CSCC join channel
 func JoinChainHandler(handle JoinChain) JoinChain {
 	return handle
 }
 
 //RegisterChannelInitializer registers channel initializer using given plugin mapper and create chain handle
-func RegisterChannelInitializer(plugin.Mapper, CreateChain) {
+func RegisterChannelInitializer(plugin.Mapper, CreateChain, InitChain) {
 	//do nothing
 }

--- a/extensions/storage/recover/recoverdb.go
+++ b/extensions/storage/recover/recoverdb.go
@@ -7,6 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package recover
 
 //RecoverDBHandler provides extension for recover db handler
-func RecoverDBHandler(handle func() error) func() error {
+func DBRecoveryHandler(handle func() error) func() error {
 	return handle
 }

--- a/extensions/storage/recover/recoverdb_test.go
+++ b/extensions/storage/recover/recoverdb_test.go
@@ -18,6 +18,6 @@ func TestRecoverDBHandler(t *testing.T) {
 	handle := func() error {
 		return sampleError
 	}
-	err := RecoverDBHandler(handle)()
+	err := DBRecoveryHandler(handle)()
 	require.Equal(t, sampleError, err)
 }


### PR DESCRIPTION
- need to pass peer.InitChain(cid) as a handle to avoid import cycle
issues in fabric-peer-ext
- fixing stutter in recover.RecoverDBHandle()

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>