### PR TITLE
fix: Fix for collection config not found

### DIFF
--- a/core/endorser/endorser.go
+++ b/core/endorser/endorser.go
@@ -22,9 +22,12 @@ import (
 	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/common/validation"
 	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/peer"
 	xendorser "github.com/hyperledger/fabric/extensions/endorser"
+	xendorserapi "github.com/hyperledger/fabric/extensions/endorser/api"
 	"github.com/hyperledger/fabric/internal/pkg/identity"
 	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/hyperledger/fabric/protoutil"
@@ -103,13 +106,18 @@ type Support interface {
 	GetDeployedCCInfoProvider() ledger.DeployedChaincodeInfoProvider
 }
 
+type rwSetFilter interface {
+	Filter(channelID string, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error)
+}
+
 // Endorser provides the Endorser service ProcessProposal
 type Endorser struct {
 	distributePrivateData privateDataDistributor
 	s                     Support
 	PlatformRegistry      *platforms.Registry
 	PvtRWSetAssembler
-	Metrics *EndorserMetrics
+	Metrics     *EndorserMetrics
+	rwSetFilter rwSetFilter
 }
 
 // validateResult provides the result of endorseProposal verification
@@ -121,6 +129,16 @@ type validateResult struct {
 	resp    *pb.ProposalResponse
 }
 
+type ledgerProvider func(cid string) ledger.PeerLedger
+
+type qeProviderFactory struct {
+	getLedger ledgerProvider
+}
+
+func (q *qeProviderFactory) GetQueryExecutorProvider(channelID string) xendorserapi.QueryExecutorProvider {
+	return q.getLedger(channelID)
+}
+
 // NewEndorserServer creates and returns a new Endorser server instance.
 func NewEndorserServer(privDist privateDataDistributor, s Support, pr *platforms.Registry, metricsProv metrics.Provider) *Endorser {
 	e := &Endorser{
@@ -129,6 +147,11 @@ func NewEndorserServer(privDist privateDataDistributor, s Support, pr *platforms
 		PlatformRegistry:      pr,
 		PvtRWSetAssembler:     &rwSetAssembler{},
 		Metrics:               NewEndorserMetrics(metricsProv),
+		rwSetFilter: xendorser.NewCollRWSetFilter(
+			&qeProviderFactory{
+				getLedger: peer.GetLedger,
+			},
+			peer.BlockPublisher),
 	}
 	return e
 }
@@ -271,7 +294,6 @@ func (e *Endorser) SimulateProposal(txParams *ccprovider.TransactionParams, cid 
 			return nil, nil, nil, nil, err
 		}
 
-		var collConfigs map[string]*common.CollectionConfigPackage
 		if simResult.PvtSimulationResults != nil {
 			if cid.Name == "lscc" {
 				// TODO: remove once we can store collection configuration outside of LSCC
@@ -299,11 +321,10 @@ func (e *Endorser) SimulateProposal(txParams *ccprovider.TransactionParams, cid 
 			if err := e.distributePrivateData(txParams.ChannelID, txParams.TxID, pvtDataWithConfig, endorsedAt); err != nil {
 				return nil, nil, nil, nil, err
 			}
-			collConfigs = pvtDataWithConfig.CollectionConfigs
 		}
 
 		txParams.TXSimulator.Done()
-		pubSimRes, err := xendorser.FilterPubSimulationResults(collConfigs, simResult.PubSimulationResults)
+		pubSimRes, err := e.rwSetFilter.Filter(txParams.ChannelID, simResult.PubSimulationResults)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}

--- a/extensions/endorser/api/endorser.go
+++ b/extensions/endorser/api/endorser.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"github.com/hyperledger/fabric/core/ledger"
+	xgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+)
+
+// QueryExecutorProvider returns a query executor
+type QueryExecutorProvider interface {
+	NewQueryExecutor() (ledger.QueryExecutor, error)
+}
+
+// QueryExecutorProviderFactory returns a query executor provider for a given channel
+type QueryExecutorProviderFactory interface {
+	GetQueryExecutorProvider(channelID string) QueryExecutorProvider
+}
+
+// BlockPublisherProvider returns a block publisher for a given channel
+type BlockPublisherProvider interface {
+	ForChannel(channelID string) xgossipapi.BlockPublisher
+}

--- a/extensions/endorser/endorser.go
+++ b/extensions/endorser/endorser.go
@@ -7,12 +7,25 @@ SPDX-License-Identifier: Apache-2.0
 package endorser
 
 import (
-	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/extensions/endorser/api"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 )
 
-// FilterPubSimulationResults filters the public simulation results and returns the filtered results or error.
-// The default implementation does not perform any filtering.
-func FilterPubSimulationResults(_ map[string]*common.CollectionConfigPackage, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
+// CollRWSetFilter filters out all off-ledger (including transient data) read-write sets from the simulation results
+// so that they won't be included in the block.
+type CollRWSetFilter interface {
+	Filter(channelID string, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error)
+}
+
+// NewCollRWSetFilter returns a new collection RW set filter
+func NewCollRWSetFilter(api.QueryExecutorProviderFactory, api.BlockPublisherProvider) CollRWSetFilter {
+	return &collRWSetFilter{}
+}
+
+type collRWSetFilter struct {
+}
+
+// Filter is a noop filter. It simply returns the passed in r/w set
+func (f *collRWSetFilter) Filter(channelID string, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
 	return pubSimulationResults, nil
 }

--- a/extensions/endorser/endorser_test.go
+++ b/extensions/endorser/endorser_test.go
@@ -9,14 +9,36 @@ package endorser
 import (
 	"testing"
 
-	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/extensions/endorser/api"
+	xgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	channelID = "testchannel"
 )
 
 func TestFilterPubSimulationResults(t *testing.T) {
+	f := NewCollRWSetFilter(&mockQEProviderFactory{}, &mockBlockPublisherProvider{})
+	require.NotNil(t, f)
 	pubSimulationResults := &rwset.TxReadWriteSet{}
-	p, err := FilterPubSimulationResults(map[string]*common.CollectionConfigPackage{}, pubSimulationResults)
+	p, err := f.Filter(channelID, pubSimulationResults)
 	assert.NoError(t, err)
 	assert.Equal(t, pubSimulationResults, p)
+}
+
+type mockQEProviderFactory struct {
+}
+
+func (q *mockQEProviderFactory) GetQueryExecutorProvider(channelID string) api.QueryExecutorProvider {
+	return nil
+}
+
+type mockBlockPublisherProvider struct {
+}
+
+func (p *mockBlockPublisherProvider) ForChannel(channelID string) xgossipapi.BlockPublisher {
+	return nil
 }


### PR DESCRIPTION
The collection config package that is assembled by the endorser removes
configs for collections in which there was no write set and therefore
the error 'config for collection [xxx] not found' results. This commit
removes the dependency on the collection config package and uses the
collection config retriever to manage collection configs.

closes #98

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>