### PR TITLE
feat: Load system chaincode from extension

### DIFF
--- a/extensions/chaincode/scc.go
+++ b/extensions/chaincode/scc.go
@@ -1,0 +1,14 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import "github.com/hyperledger/fabric/core/scc"
+
+// CreateSCC returns list of System ChainCodes provided by extensions
+func CreateSCC(providers ...interface{}) []scc.SelfDescribingSysCC {
+	return nil
+}

--- a/extensions/chaincode/scc_test.go
+++ b/extensions/chaincode/scc_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSCC(t *testing.T) {
+	require.Empty(t, CreateSCC())
+}

--- a/internal/peer/node/gossipprovider.go
+++ b/internal/peer/node/gossipprovider.go
@@ -1,0 +1,25 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package node
+
+import (
+	"github.com/hyperledger/fabric/gossip/service"
+)
+
+// gossipProvider is a Gossip service provider
+type gossipProvider struct {
+}
+
+// newGossipProvider returns a new Gossip service provider
+func newGossipProvider() *gossipProvider {
+	return &gossipProvider{}
+}
+
+// GetGossipService returns the GossipService
+func (p *gossipProvider) GetGossipService() service.GossipService {
+	return service.GetGossipService()
+}

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -71,6 +71,7 @@ import (
 	ccsupport "github.com/hyperledger/fabric/discovery/support/chaincode"
 	"github.com/hyperledger/fabric/discovery/support/config"
 	"github.com/hyperledger/fabric/discovery/support/gossip"
+	extcc "github.com/hyperledger/fabric/extensions/chaincode"
 	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
 	collretriever "github.com/hyperledger/fabric/extensions/collections/retriever"
 	gossipcommon "github.com/hyperledger/fabric/gossip/common"
@@ -484,7 +485,13 @@ func serve(args []string) error {
 
 	//Now that chaincode is initialized, register all system chaincodes.
 	sccs := scc.CreatePluginSysCCs(sccp)
-	for _, cc := range append([]scc.SelfDescribingSysCC{lsccInst, csccInst, qsccInst, lifecycleSCC}, sccs...) {
+
+	// get the list of system chain codes provided by extensions
+	extscc := extcc.CreateSCC(
+		sccp, aclProvider, lifecycleValidatorCommitter,
+		newGossipProvider(), peer.BlockPublisher)
+
+	for _, cc := range append([]scc.SelfDescribingSysCC{lsccInst, csccInst, qsccInst, lifecycleSCC}, append(sccs, extscc...)...) {
 		sccp.RegisterSysCC(cc)
 	}
 	pb.RegisterChaincodeSupportServer(ccSrv.Server(), ccSupSrv)


### PR DESCRIPTION
Added a hook to load all extended system chaincodes and register them along
with the built-in system chaincodes.

closes #67

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
Co-authored-by: Rolson Quadras <rolson.quadras@securekey.com>