### PR TITLE
feat: gossip extensions to support role based features

### DIFF
--- a/core/committer/committer_impl.go
+++ b/core/committer/committer_impl.go
@@ -67,9 +67,9 @@ func NewLedgerCommitterReactive(ledger PeerLedgerSupport, eventer BlockEventer) 
 	return &LedgerCommitter{PeerLedgerSupport: ledger, eventer: eventer}
 }
 
-// preCommit takes care to validate the block and update based on its
+// PreCommit takes care to validate the block and update based on its
 // content
-func (lc *LedgerCommitter) preCommit(block *common.Block) error {
+func (lc *LedgerCommitter) PreCommit(block *common.Block) error {
 	logger.Debug("Received block, calling eventer")
 	if err := lc.eventer(block); err != nil {
 		return errors.WithMessage(err, "error returned from block eventer")
@@ -81,7 +81,7 @@ func (lc *LedgerCommitter) preCommit(block *common.Block) error {
 func (lc *LedgerCommitter) CommitWithPvtData(blockAndPvtData *ledger.BlockAndPvtData) error {
 	// Do validation and whatever needed before
 	// committing new block
-	if err := lc.preCommit(blockAndPvtData.Block); err != nil {
+	if err := lc.PreCommit(blockAndPvtData.Block); err != nil {
 		return err
 	}
 

--- a/core/deliverservice/blocksprovider/blocksprovider.go
+++ b/core/deliverservice/blocksprovider/blocksprovider.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	xgossipservice "github.com/hyperledger/fabric/extensions/gossip/service"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/gossip/api"
@@ -182,7 +184,7 @@ func (b *blocksProviderImpl) DeliverBlocks() {
 			// Gossip messages with other nodes
 			logger.Debugf("[%s] Gossiping block [%d], peers number [%d]", b.chainID, blockNum, numberOfPeers)
 			if !b.isDone() {
-				b.gossip.Gossip(gossipMsg)
+				xgossipservice.HandleGossip(b.gossip.Gossip)(gossipMsg)
 			}
 		default:
 			logger.Warningf("[%s] Received unknown: %v", b.chainID, t)

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -301,7 +301,7 @@ func Initialize(
 	}
 
 	//register channel initializer with create chain and init chain handlers
-	xchannel.RegisterChannelInitializer(pm, createChain, InitChain)
+	xchannel.RegisterChannelInitializer(pm, createChain, InitChain, getCurrConfigBlockFromLedger)
 }
 
 // InitChain takes care to initialize chain after peer joined, for example deploys system CCs
@@ -492,6 +492,7 @@ func createChain(cid string, ledger ledger.PeerLedger, cb *common.Block,
 		IdDeserializeFactory: csStoreSupport,
 		Ledger:               ledger,
 		BlockPublisher:       blockPublisher,
+		BlockEventer:         c,
 	})
 
 	chains.Lock()

--- a/extensions/channel/channel.go
+++ b/extensions/channel/channel.go
@@ -22,12 +22,14 @@ type CreateChain func(string, ledger.PeerLedger, *common.Block, sysccprovider.Sy
 
 type InitChain func(string)
 
+type CurrentConfigBlock func(ledger ledger.PeerLedger) (*common.Block, error)
+
 //JoinChainHandler can be used to provide extended features to CSCC join channel
 func JoinChainHandler(handle JoinChain) JoinChain {
 	return handle
 }
 
 //RegisterChannelInitializer registers channel initializer using given plugin mapper and create chain handle
-func RegisterChannelInitializer(plugin.Mapper, CreateChain, InitChain) {
+func RegisterChannelInitializer(plugin.Mapper, CreateChain, InitChain, CurrentConfigBlock) {
 	//do nothing
 }

--- a/extensions/gossip/api/gossipapi.go
+++ b/extensions/gossip/api/gossipapi.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
+	"github.com/hyperledger/fabric/core/ledger"
 	cb "github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
 	pb "github.com/hyperledger/fabric/protos/peer"
@@ -41,6 +42,8 @@ type BlockPublisher interface {
 	AddCCEventHandler(handler ChaincodeEventHandler)
 	// Publish traverses the block and invokes all applicable handlers
 	Publish(block *cb.Block)
+	//LedgerHeight returns current in memory ledger height
+	LedgerHeight() uint64
 }
 
 // TxMetadata contain txn metadata
@@ -49,4 +52,24 @@ type TxMetadata struct {
 	TxNum     uint64
 	ChannelID string
 	TxID      string
+}
+
+//BlockEventer performs pre commit operation for a block
+type BlockEventer interface {
+	//PreCommit performs pre commit operation for given block
+	PreCommit(block *cb.Block) error
+}
+
+//LedgerHeightProvider provides current ledger height
+type LedgerHeightProvider interface {
+	//LedgerHeight  returns current in-memory ledger height
+	LedgerHeight() uint64
+}
+
+// Support aggregates functionality of several
+// interfaces required by gossip service
+type Support struct {
+	Ledger               ledger.PeerLedger
+	LedgerHeightProvider LedgerHeightProvider
+	BlockEventer         BlockEventer
 }

--- a/extensions/gossip/blockpublisher/blockpublisher.go
+++ b/extensions/gossip/blockpublisher/blockpublisher.go
@@ -56,3 +56,8 @@ func (p *publisher) AddCCEventHandler(handler api.ChaincodeEventHandler) {
 func (p *publisher) Publish(block *cb.Block) {
 	// Not implemented
 }
+
+func (p *publisher) LedgerHeight() uint64 {
+	// Not implemented
+	return 0
+}

--- a/extensions/gossip/mocks/blockpublisher.go
+++ b/extensions/gossip/mocks/blockpublisher.go
@@ -49,3 +49,9 @@ func (m *BlockPublisher) AddCCEventHandler(handler api.ChaincodeEventHandler) {
 func (m *BlockPublisher) Publish(block *cb.Block) {
 	// Not implemented
 }
+
+// Publish traverses the block and invokes all applicable handlers
+func (m *BlockPublisher) LedgerHeight() uint64 {
+	// Not implemented
+	return 0
+}

--- a/extensions/gossip/service/service.go
+++ b/extensions/gossip/service/service.go
@@ -1,0 +1,15 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"github.com/hyperledger/fabric/protos/gossip"
+)
+
+func HandleGossip(handle func(msg *gossip.GossipMessage)) func(msg *gossip.GossipMessage) {
+	return handle
+}

--- a/extensions/gossip/service/service_test.go
+++ b/extensions/gossip/service/service_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/protos/gossip"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGossip(t *testing.T) {
+
+	doneCh := make(chan bool, 1)
+	handle := func(msg *gossip.GossipMessage) {
+		doneCh <- true
+	}
+	HandleGossip(handle)(nil)
+
+	select {
+	case ok := <-doneCh:
+		require.True(t, ok)
+	default:
+		t.Fatal("handler supposed to be executed")
+	}
+}

--- a/extensions/gossip/state/state.go
+++ b/extensions/gossip/state/state.go
@@ -22,9 +22,6 @@ type GossipStateProviderExtension interface {
 	//HandleStateRequest can used to extend given request handle
 	HandleStateRequest(func(msg protoext.ReceivedMessage)) func(msg protoext.ReceivedMessage)
 
-	//AntiEntropy can be used to extend Anti Entropy features
-	AntiEntropy(func()) func()
-
 	//Predicate can used to override existing predicate to filter peers to be asked for blocks
 	Predicate(func(peer discovery.NetworkMember) bool) func(peer discovery.NetworkMember) bool
 
@@ -33,6 +30,12 @@ type GossipStateProviderExtension interface {
 
 	//StoreBlock  can used to extend given store block handle
 	StoreBlock(func(block *common.Block, pvtData util.PvtDataCollections) error) func(block *common.Block, pvtData util.PvtDataCollections) error
+
+	//LedgerHeight can used to extend ledger height feature to get current ledger height
+	LedgerHeight(func() (uint64, error)) func() (uint64, error)
+
+	//RequestBlocksInRange can be used to extend given request blocks feature
+	RequestBlocksInRange(func(start uint64, end uint64), func(payload *proto.Payload, blockingMode bool) error) func(start uint64, end uint64)
 }
 
 // GossipServiceMediator aggregated adapter interface to compound basic mediator services
@@ -57,7 +60,7 @@ func AddBlockHandler(publisher api.BlockPublisher) {
 }
 
 //NewGossipStateProviderExtension returns new GossipStateProvider Extension implementation
-func NewGossipStateProviderExtension(chainID string, mediator GossipServiceMediator) GossipStateProviderExtension {
+func NewGossipStateProviderExtension(chainID string, mediator GossipServiceMediator, support *api.Support) GossipStateProviderExtension {
 	return &gossipStateProviderExtension{}
 }
 
@@ -65,10 +68,6 @@ type gossipStateProviderExtension struct {
 }
 
 func (s *gossipStateProviderExtension) HandleStateRequest(handle func(msg protoext.ReceivedMessage)) func(msg protoext.ReceivedMessage) {
-	return handle
-}
-
-func (s *gossipStateProviderExtension) AntiEntropy(handle func()) func() {
 	return handle
 }
 
@@ -81,5 +80,13 @@ func (s *gossipStateProviderExtension) AddPayload(handle func(payload *proto.Pay
 }
 
 func (s *gossipStateProviderExtension) StoreBlock(handle func(block *common.Block, pvtData util.PvtDataCollections) error) func(block *common.Block, pvtData util.PvtDataCollections) error {
+	return handle
+}
+
+func (s *gossipStateProviderExtension) LedgerHeight(handle func() (uint64, error)) func() (uint64, error) {
+	return handle
+}
+
+func (s *gossipStateProviderExtension) RequestBlocksInRange(handle func(start uint64, end uint64), addPayload func(payload *proto.Payload, blockingMode bool) error) func(start uint64, end uint64) {
 	return handle
 }

--- a/extensions/gossip/state/state_test.go
+++ b/extensions/gossip/state/state_test.go
@@ -34,9 +34,16 @@ func TestProviderExtension(t *testing.T) {
 		return sampleError
 	}
 
-	extension := NewGossipStateProviderExtension("test", nil)
+	handleLedgerheight := func() (uint64, error) {
+		return 99, nil
+	}
+
+	extension := NewGossipStateProviderExtension("test", nil, nil)
 	require.Error(t, sampleError, extension.AddPayload(handleAddPayload))
 	require.True(t, extension.Predicate(predicate)(discovery.NetworkMember{}))
 	require.Error(t, sampleError, extension.StoreBlock(handleStoreBlock))
+	height, err := extension.LedgerHeight(handleLedgerheight)()
+	require.Equal(t, 99, int(height))
+	require.NoError(t, err)
 
 }

--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -250,6 +250,7 @@ type Support struct {
 	CollDataStore        storeapi.Store
 	Ledger               ledger.PeerLedger
 	BlockPublisher       extgossipapi.BlockPublisher
+	BlockEventer         extgossipapi.BlockEventer
 }
 
 // DataStoreSupport aggregates interfaces capable
@@ -316,7 +317,7 @@ func (g *gossipServiceImpl) InitializeChannel(chainID string, endpoints []string
 	blockingMode := !viper.GetBool("peer.gossip.nonBlockingCommitMode")
 	g.chains[chainID] = state.NewGossipStateProvider(chainID, servicesAdapter, coordinator,
 		g.metrics.StateMetrics, blockingMode,
-		dispatcher.New(chainID, support.CollDataStore, servicesAdapter, support.Ledger, support.BlockPublisher), support.Ledger)
+		dispatcher.New(chainID, support.CollDataStore, servicesAdapter, support.Ledger, support.BlockPublisher), &extgossipapi.Support{Ledger: support.Ledger, LedgerHeightProvider: support.BlockPublisher, BlockEventer: support.BlockEventer})
 	if g.deliveryService[chainID] == nil {
 		var err error
 		g.deliveryService[chainID], err = g.deliveryFactory.Service(g, endpoints, g.mcs)

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	xgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	"math/rand"
 	"net"
 	"sync"
@@ -409,7 +410,7 @@ func newPeerNodeWithGossipWithValidatorWithMetrics(id int, committer committer.C
 		TransientStore: &mockTransientStore{},
 		Committer:      committer,
 	}, protoutil.SignedData{}, gossipMetrics.PrivdataMetrics, coordConfig)
-	sp := NewGossipStateProvider(util.GetTestChainID(), servicesAdapater, coord, gossipMetrics.StateMetrics, blocking, nil, nil)
+	sp := NewGossipStateProvider(util.GetTestChainID(), servicesAdapater, coord, gossipMetrics.StateMetrics, blocking, nil, &xgossipapi.Support{})
 	if sp == nil {
 		gRPCServer.Stop()
 		return nil, port
@@ -1382,7 +1383,7 @@ func TestTransferOfPrivateRWSet(t *testing.T) {
 
 	servicesAdapater := &ServicesMediator{GossipAdapter: g, MCSAdapter: &cryptoServiceMock{acceptor: noopPeerIdentityAcceptor}}
 	stateMetrics := metrics.NewGossipMetrics(&disabled.Provider{}).StateMetrics
-	st := NewGossipStateProvider(chainID, servicesAdapater, coord1, stateMetrics, blocking, nil, nil)
+	st := NewGossipStateProvider(chainID, servicesAdapater, coord1, stateMetrics, blocking, nil, &xgossipapi.Support{})
 	defer st.Stop()
 
 	// Mocked state request message
@@ -1618,11 +1619,11 @@ func TestTransferOfPvtDataBetweenPeers(t *testing.T) {
 	stateMetrics := metrics.NewGossipMetrics(&disabled.Provider{}).StateMetrics
 
 	mediator := &ServicesMediator{GossipAdapter: peers["peer1"], MCSAdapter: cryptoService}
-	peer1State := NewGossipStateProvider(chainID, mediator, peers["peer1"].coord, stateMetrics, blocking, nil, nil)
+	peer1State := NewGossipStateProvider(chainID, mediator, peers["peer1"].coord, stateMetrics, blocking, nil, &xgossipapi.Support{})
 	defer peer1State.Stop()
 
 	mediator = &ServicesMediator{GossipAdapter: peers["peer2"], MCSAdapter: cryptoService}
-	peer2State := NewGossipStateProvider(chainID, mediator, peers["peer2"].coord, stateMetrics, blocking, nil, nil)
+	peer2State := NewGossipStateProvider(chainID, mediator, peers["peer2"].coord, stateMetrics, blocking, nil, &xgossipapi.Support{})
 	defer peer2State.Stop()
 
 	// Make sure state was replicated


### PR DESCRIPTION
- role based extension in anti entropy while request new blocks
- role based extension for ledger height calculations
- ChannelInitializer extension to use current config block
- role based extension for gossip in deliveryservice  blocks provider
- block publisher to provide ledger height info
related to #96

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>