### PR TITLE
feat: Checkpoint block implementation in block store

### DIFF
--- a/common/ledger/blkstorage/blockstorage.go
+++ b/common/ledger/blkstorage/blockstorage.go
@@ -9,6 +9,7 @@ package blkstorage
 import (
 	"github.com/hyperledger/fabric/common/ledger"
 	l "github.com/hyperledger/fabric/core/ledger"
+	xblkstorage "github.com/hyperledger/fabric/extensions/storage/blkstorage/api"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/peer"
 	"github.com/pkg/errors"
@@ -53,6 +54,7 @@ type BlockStoreProvider interface {
 // An implementation of this interface is expected to take an argument
 // of type `IndexConfig` which configures the block store on what items should be indexed
 type BlockStore interface {
+	xblkstorage.BlockStoreExtension
 	AddBlock(block *common.Block) error
 	GetBlockchainInfo() (*common.BlockchainInfo, error)
 	RetrieveBlocks(startNum uint64) (ledger.ResultsIterator, error)

--- a/common/ledger/blkstorage/fsblkstorage/fs_blockstore.go
+++ b/common/ledger/blkstorage/fsblkstorage/fs_blockstore.go
@@ -1,17 +1,7 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
 
 package fsblkstorage
@@ -78,6 +68,10 @@ func (store *fsBlockStore) RetrieveBlockByTxID(txID string) (*common.Block, erro
 
 func (store *fsBlockStore) RetrieveTxValidationCodeByTxID(txID string) (peer.TxValidationCode, error) {
 	return store.fileMgr.retrieveTxValidationCodeByTxID(txID)
+}
+
+func (store *fsBlockStore) CheckpointBlock(block *common.Block) error {
+	return nil
 }
 
 // Shutdown shuts down the block store

--- a/common/ledger/blockledger/file/impl_test.go
+++ b/common/ledger/blockledger/file/impl_test.go
@@ -108,6 +108,10 @@ func (mbs *mockBlockStore) RetrieveTxValidationCodeByTxID(txID string) (peer.TxV
 	return mbs.txValidationCode, mbs.defaultError
 }
 
+func (mbs *mockBlockStore) CheckpointBlock(block *cb.Block) error {
+	return mbs.defaultError
+}
+
 func (*mockBlockStore) Shutdown() {
 }
 

--- a/core/chaincode/mock/peer_ledger.go
+++ b/core/chaincode/mock/peer_ledger.go
@@ -1277,3 +1277,7 @@ func (fake *PeerLedger) recordInvocation(key string, args []interface{}) {
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
+
+func (fake *PeerLedger) CheckpointBlock(block *common.Block) error {
+	return nil
+}

--- a/core/committer/committer_test.go
+++ b/core/committer/committer_test.go
@@ -121,6 +121,10 @@ func (m *mockLedger) GetMissingPvtDataTracker() (ledger2.MissingPvtDataTracker, 
 	panic("implement me")
 }
 
+func (m *mockLedger) CheckpointBlock(block *common.Block) error {
+	return nil
+}
+
 func createLedger(channelID string) (*common.Block, *mockLedger) {
 	gb, _ := test.MakeGenesisBlock(channelID)
 	ledger := &mockLedger{

--- a/core/committer/txvalidator/v14/validator_test.go
+++ b/core/committer/txvalidator/v14/validator_test.go
@@ -1743,6 +1743,9 @@ func (m *mockLedger) GetBlocksIterator(startBlockNumber uint64) (ledger2.Results
 func (m *mockLedger) Close() {
 
 }
+func (m *mockLedger) CheckpointBlock(block *common.Block) error {
+	return nil
+}
 
 func (m *mockLedger) Commit(block *common.Block) error {
 	return nil

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package kvledger
 
 import (
+	xledger "github.com/hyperledger/fabric/extensions/ledger"
+	xledgerapi "github.com/hyperledger/fabric/extensions/ledger/api"
 	"sync"
 	"time"
 
@@ -36,6 +38,7 @@ var logger = flogging.MustGetLogger("kvledger")
 // KVLedger provides an implementation of `ledger.PeerLedger`.
 // This implementation provides a key-value based data model
 type kvLedger struct {
+	xledgerapi.PeerLedgerExtension
 	ledgerID               string
 	blockStore             *ledgerstorage.Store
 	txtmgmt                txmgr.TxMgr
@@ -62,7 +65,7 @@ func newKVLedger(
 	logger.Debugf("Creating KVLedger ledgerID=%s: ", ledgerID)
 	// Create a kvLedger for this chain/ledger, which encasulates the underlying
 	// id store, blockstore, txmgr (state database), history database
-	l := &kvLedger{ledgerID: ledgerID, blockStore: blockStore, historyDB: historyDB, blockAPIsRWLock: &sync.RWMutex{}}
+	l := &kvLedger{PeerLedgerExtension: xledger.NewKVLedgerExtension(blockStore), ledgerID: ledgerID, blockStore: blockStore, historyDB: historyDB, blockAPIsRWLock: &sync.RWMutex{}}
 
 	btlPolicy := pvtdatapolicy.ConstructBTLPolicy(&collectionInfoRetriever{ledgerID, l, ccInfoProvider})
 	if err := l.initTxMgr(versionedDB, stateListeners, btlPolicy, bookkeeperProvider, ccInfoProvider, collDataProvider); err != nil {

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -9,6 +9,7 @@ package ledger
 import (
 	"fmt"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
+	xledgerapi "github.com/hyperledger/fabric/extensions/ledger/api"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-lib-go/healthz"
@@ -98,6 +99,7 @@ type PeerLedgerProvider interface {
 // that tells apart valid transactions from invalid ones
 type PeerLedger interface {
 	commonledger.Ledger
+	xledgerapi.PeerLedgerExtension
 	// GetTransactionByID retrieves a transaction by id
 	GetTransactionByID(txID string) (*peer.ProcessedTransaction, error)
 	// GetBlockByHash returns a block given it's hash

--- a/core/ledger/ledgerstorage/store.go
+++ b/core/ledger/ledgerstorage/store.go
@@ -250,6 +250,11 @@ func (s *Store) ResetLastUpdatedOldBlocksList() error {
 	return s.pvtdataStore.ResetLastUpdatedOldBlocksList()
 }
 
+// CheckpointBlock updates checkpoint info of underlying blockstore with given block
+func (s *Store) CheckpointBlock(block *common.Block) error {
+	return s.BlockStore.CheckpointBlock(block)
+}
+
 // init first invokes function `initFromExistingBlockchain`
 // in order to check whether the pvtdata store is present because of an upgrade
 // of peer from 1.0 and need to be updated with the existing blockchain. If, this is

--- a/extensions/ledger/api/ledgerapi.go
+++ b/extensions/ledger/api/ledgerapi.go
@@ -1,0 +1,15 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import "github.com/hyperledger/fabric/protos/common"
+
+//PeerLedgerExtension is an extension to PeerLedger interface which can be used to extend existing peer ledger features.
+type PeerLedgerExtension interface {
+	//CheckpointBlock updates check point info in underlying store
+	CheckpointBlock(block *common.Block) error
+}

--- a/extensions/ledger/kvledger.go
+++ b/extensions/ledger/kvledger.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ledger
+
+import (
+	"github.com/hyperledger/fabric/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric/extensions/ledger/api"
+	"github.com/hyperledger/fabric/protos/common"
+)
+
+//NewKVLedgerExtension returns peer ledger extension implementation using block store provided
+func NewKVLedgerExtension(store blkstorage.BlockStore) api.PeerLedgerExtension {
+	return &kvLedger{store}
+}
+
+//kvLedger is implementation of Peer Ledger extension
+type kvLedger struct {
+	blockStore blkstorage.BlockStore
+}
+
+// CheckpointBlock updates checkpoint info of underlying blockstore with given block
+func (l *kvLedger) CheckpointBlock(block *common.Block) error {
+	return l.blockStore.CheckpointBlock(block)
+}

--- a/extensions/ledger/kvledger_test.go
+++ b/extensions/ledger/kvledger_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ledger
+
+import (
+	"errors"
+	"github.com/hyperledger/fabric/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const errMsg = "not implemented"
+
+func TestKVLedgerExtension(t *testing.T) {
+	xtn := NewKVLedgerExtension(&mockBlockStore{})
+	require.NotNil(t, xtn)
+	require.Error(t, xtn.CheckpointBlock(nil), errMsg)
+}
+
+type mockBlockStore struct {
+	blkstorage.BlockStore
+}
+
+func (mbs *mockBlockStore) CheckpointBlock(block *common.Block) error {
+	return errors.New(errMsg)
+}

--- a/extensions/storage/blkstorage/api/blkstorageapi.go
+++ b/extensions/storage/blkstorage/api/blkstorageapi.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blkstorage
+
+import (
+	"github.com/hyperledger/fabric/protos/common"
+)
+
+//BlockStoreExtension is an extension to blkstorage.BlockStore interface which can be used to extend existing block store features.
+type BlockStoreExtension interface {
+	//CheckpointBlock updates checkpoint info of blockstore with given block
+	CheckpointBlock(block *common.Block) error
+}


### PR DESCRIPTION
- added extension to existing block store interface to add check point
block features which can be used to maintain local checkpoint info on
current block status of the store.
- also added corresponding extensions in PeerLedger so that it can be
used to update checkpoint info in underlying blockstore.
-fsb block store implementation doesn't support blockstore checkpoints
-related to #108

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>