### PR TITLE
feat: lscc state cache clear on CC upgrade

### DIFF
--- a/core/endorser/endorser.go
+++ b/core/endorser/endorser.go
@@ -9,6 +9,7 @@ package endorser
 import (
 	"context"
 	"fmt"
+	"github.com/hyperledger/fabric/extensions/gossip/blockpublisher"
 	"strconv"
 	"time"
 
@@ -151,7 +152,7 @@ func NewEndorserServer(privDist privateDataDistributor, s Support, pr *platforms
 			&qeProviderFactory{
 				getLedger: peer.GetLedger,
 			},
-			peer.BlockPublisher),
+			blockpublisher.GetProvider()),
 	}
 	return e
 }

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/ccupgradehandler.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/ccupgradehandler.go
@@ -1,0 +1,22 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statecouchdb
+
+import (
+	"github.com/hyperledger/fabric/extensions/gossip/api"
+)
+
+const lsccKeyPrefix = "%s~"
+
+//getCCUpgradeHandler returns block publisher chaincode upgrade handler related to given versioned DB instance
+func getCCUpgradeHandler(vdb *VersionedDB) api.ChaincodeUpgradeHandler {
+	return func(txMetadata api.TxMetadata, chaincodeName string) error {
+		logger.Debugf("Clearing lscc state cache for chaincode [%s]", chaincodeName)
+		vdb.lsccStateCache.evictEntry(chaincodeName)
+		return nil
+	}
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/ccupgradehandler_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/ccupgradehandler_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statecouchdb
+
+import (
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/extensions/gossip/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCCUpgradeHandler(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+
+	db, err := env.DBProvider.GetDBHandle("testinit")
+	assert.NoError(t, err)
+	db.Open()
+	defer db.Close()
+
+	initLen := len(db.(*VersionedDB).lsccStateCache.cache)
+	db.(*VersionedDB).lsccStateCache.cache["samplecc"] = &statedb.VersionedValue{Value: []byte("samplecc")}
+	db.(*VersionedDB).lsccStateCache.cache["samplecc~collection"] = &statedb.VersionedValue{Value: []byte("samplecc~collection")}
+	db.(*VersionedDB).lsccStateCache.cache["samplecc2"] = &statedb.VersionedValue{Value: []byte("samplecc2")}
+	db.(*VersionedDB).lsccStateCache.cache["samplecc2~collection"] = &statedb.VersionedValue{Value: []byte("samplecc2~collection")}
+
+	handler := getCCUpgradeHandler(db.(*VersionedDB))
+	err = handler(api.TxMetadata{}, "samplecc")
+	require.NoError(t, err)
+	require.Len(t, db.(*VersionedDB).lsccStateCache.cache, initLen+2)
+
+	err = handler(api.TxMetadata{}, "samplecc2")
+	require.NoError(t, err)
+	require.Len(t, db.(*VersionedDB).lsccStateCache.cache, initLen)
+}

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -115,9 +115,6 @@ func CollectionDataStoreFactory() CollStoreProvider {
 	return collectionDataStoreFactory
 }
 
-// publisher manages the block publishers for all channels
-var BlockPublisher = blockpublisher.NewProvider()
-
 type storeProvider struct {
 	stores map[string]transientstore.Store
 	transientstore.StoreProvider
@@ -446,8 +443,8 @@ func createChain(cid string, ledger ledger.PeerLedger, cb *common.Block,
 		ChannelID:                       bundle.ConfigtxValidator().ChainID(),
 	}, sccp, pm, NewChannelPolicyManagerGetter())
 
-	blockPublisher := BlockPublisher.ForChannel(cid)
-	xstate.AddBlockHandler(blockPublisher)
+	blkPublisher := blockpublisher.GetProvider().ForChannel(cid)
+	xstate.AddBlockHandler(blkPublisher)
 
 	c := committer.NewLedgerCommitterReactive(ledger, func(block *common.Block) error {
 		// Updating CSCC with new configuration block
@@ -459,7 +456,7 @@ func createChain(cid string, ledger ledger.PeerLedger, cb *common.Block,
 			}
 		}
 		// Inform applicable registered handlers of the new block
-		blockPublisher.Publish(block)
+		blkPublisher.Publish(block)
 		return nil
 	})
 
@@ -491,7 +488,7 @@ func createChain(cid string, ledger ledger.PeerLedger, cb *common.Block,
 		Cs:                   simpleCollectionStore,
 		IdDeserializeFactory: csStoreSupport,
 		Ledger:               ledger,
-		BlockPublisher:       blockPublisher,
+		BlockPublisher:       blkPublisher,
 		BlockEventer:         c,
 	})
 

--- a/extensions/gossip/blockpublisher/blockpublisher.go
+++ b/extensions/gossip/blockpublisher/blockpublisher.go
@@ -9,7 +9,11 @@ package blockpublisher
 import (
 	"github.com/hyperledger/fabric/extensions/gossip/api"
 	cb "github.com/hyperledger/fabric/protos/common"
+	"sync"
 )
+
+var blockPublisherProvider *Provider
+var once sync.Once
 
 // Provider is a noop block publisher provider
 type Provider struct {
@@ -25,9 +29,12 @@ func (p *Provider) Close() {
 	// Nothing to do
 }
 
-// NewProvider returns a new block publisher provider
-func NewProvider() *Provider {
-	return &Provider{}
+// GetProvider returns block publisher provider
+func GetProvider() *Provider {
+	once.Do(func() {
+		blockPublisherProvider = &Provider{}
+	})
+	return blockPublisherProvider
 }
 
 type publisher struct {

--- a/extensions/gossip/blockpublisher/blockpublisher_test.go
+++ b/extensions/gossip/blockpublisher/blockpublisher_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func TestProvider(t *testing.T) {
-	p := NewProvider()
+	p := GetProvider()
 	require.NotNil(t, p)
 
 	publisher := p.ForChannel(channelID)

--- a/extensions/storage/statedb/statedb.go
+++ b/extensions/storage/statedb/statedb.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statedb
+
+import (
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+)
+
+//AddCCUpgradeHandler adds chaincode upgrade handler to blockpublisher
+func AddCCUpgradeHandler(chainName string, handler gossipapi.ChaincodeUpgradeHandler) {
+	//do nothing
+}

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -8,6 +8,7 @@ package node
 
 import (
 	"fmt"
+	"github.com/hyperledger/fabric/extensions/gossip/blockpublisher"
 	"net"
 	"net/http"
 	"os"
@@ -250,7 +251,7 @@ func serve(args []string) error {
 		func() supportapi.GossipAdapter {
 			return service.GetGossipService()
 		},
-		peer.BlockPublisher.ForChannel,
+		blockpublisher.GetProvider().ForChannel,
 	)
 
 	// initialize resource management exit
@@ -489,7 +490,7 @@ func serve(args []string) error {
 	// get the list of system chain codes provided by extensions
 	extscc := extcc.CreateSCC(
 		sccp, aclProvider, lifecycleValidatorCommitter,
-		newGossipProvider(), peer.BlockPublisher)
+		newGossipProvider(), blockpublisher.GetProvider())
 
 	for _, cc := range append([]scc.SelfDescribingSysCC{lsccInst, csccInst, qsccInst, lifecycleSCC}, append(sccs, extscc...)...) {
 		sccp.RegisterSysCC(cc)


### PR DESCRIPTION
- clearing lscc state cache for given chaincode in statecouchdb after CC
upgrade
related to #96

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>