### PR TITLE
feat: Add LSCC write events to BlockPublisher

### DIFF
--- a/extensions/gossip/api/gossipapi.go
+++ b/extensions/gossip/api/gossipapi.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
+	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/ledger"
 	cb "github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
@@ -28,6 +29,9 @@ type ChaincodeEventHandler func(txMetadata TxMetadata, event *pb.ChaincodeEvent)
 // ChaincodeUpgradeHandler handles chaincode upgrade events
 type ChaincodeUpgradeHandler func(txMetadata TxMetadata, chaincodeName string) error
 
+// LSCCWriteHandler handles chaincode instantiation/upgrade events
+type LSCCWriteHandler func(txMetadata TxMetadata, chaincodeName string, ccData *ccprovider.ChaincodeData, ccp *cb.CollectionConfigPackage) error
+
 // BlockPublisher allows clients to add handlers for various block events
 type BlockPublisher interface {
 	// AddCCUpgradeHandler adds a handler for chaincode upgrades
@@ -38,6 +42,8 @@ type BlockPublisher interface {
 	AddWriteHandler(handler WriteHandler)
 	// AddReadHandler adds a handler for KV reads
 	AddReadHandler(handler ReadHandler)
+	// AddLSCCWriteHandler adds a handler for LSCC writes (for chaincode instantiate/upgrade)
+	AddLSCCWriteHandler(handler LSCCWriteHandler)
 	// AddCCEventHandler adds a handler for chaincode events
 	AddCCEventHandler(handler ChaincodeEventHandler)
 	// Publish traverses the block and invokes all applicable handlers

--- a/extensions/gossip/blockpublisher/blockpublisher.go
+++ b/extensions/gossip/blockpublisher/blockpublisher.go
@@ -56,6 +56,10 @@ func (p *publisher) AddReadHandler(handler api.ReadHandler) {
 	// Not implemented
 }
 
+func (p *publisher) AddLSCCWriteHandler(handler api.LSCCWriteHandler) {
+	// Not implemented
+}
+
 func (p *publisher) AddCCEventHandler(handler api.ChaincodeEventHandler) {
 	// Not implemented
 }

--- a/extensions/gossip/blockpublisher/blockpublisher_test.go
+++ b/extensions/gossip/blockpublisher/blockpublisher_test.go
@@ -30,6 +30,7 @@ func TestProvider(t *testing.T) {
 		publisher.AddReadHandler(nil)
 		publisher.AddCCUpgradeHandler(nil)
 		publisher.AddCCEventHandler(nil)
+		publisher.AddLSCCWriteHandler(nil)
 		publisher.Publish(nil)
 	})
 

--- a/extensions/gossip/mocks/blockpublisher.go
+++ b/extensions/gossip/mocks/blockpublisher.go
@@ -40,6 +40,10 @@ func (m *BlockPublisher) AddReadHandler(handler api.ReadHandler) {
 	// Not implemented
 }
 
+func (p *BlockPublisher) AddLSCCWriteHandler(handler api.LSCCWriteHandler) {
+	// Not implemented
+}
+
 // AddCCEventHandler adds a handler for chaincode events
 func (m *BlockPublisher) AddCCEventHandler(handler api.ChaincodeEventHandler) {
 	// Not implemented


### PR DESCRIPTION
Added the function, AddLSCCWriteHandler, to BlockPublisher so that clients can register for chaincode instantiation and upgrade events. The handler is provided the chaincode data and collection config package.

closes #112

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>