### PR TITLE
chore: Rename AddBlockHandler

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -444,7 +444,7 @@ func createChain(cid string, ledger ledger.PeerLedger, cb *common.Block,
 	}, sccp, pm, NewChannelPolicyManagerGetter())
 
 	blkPublisher := blockpublisher.GetProvider().ForChannel(cid)
-	xstate.AddBlockHandler(blkPublisher)
+	xstate.ChannelJoined(cid, ledger, blkPublisher)
 
 	c := committer.NewLedgerCommitterReactive(ledger, func(block *common.Block) error {
 		// Updating CSCC with new configuration block

--- a/extensions/gossip/state/state.go
+++ b/extensions/gossip/state/state.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package state
 
 import (
+	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/extensions/gossip/api"
 	common2 "github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/gossip/discovery"
@@ -54,8 +55,8 @@ type GossipServiceMediator interface {
 	Gossip(msg *proto.GossipMessage)
 }
 
-//AddBlockHandler handles state update in gossip
-func AddBlockHandler(publisher api.BlockPublisher) {
+// ChannelJoined is invoked when the peer joins a channel
+func ChannelJoined(channelID string, ledger ledger.PeerLedger, publisher api.BlockPublisher) {
 	//do nothing
 }
 

--- a/extensions/gossip/state/state_test.go
+++ b/extensions/gossip/state/state_test.go
@@ -46,4 +46,7 @@ func TestProviderExtension(t *testing.T) {
 	require.Equal(t, 99, int(height))
 	require.NoError(t, err)
 
+	require.NotPanics(t, func() {
+		ChannelJoined("testchannel", nil, nil)
+	})
 }


### PR DESCRIPTION
Renamed AddBlockHandler to ChannelJoined since it's invoked when the peer joins the channel. Also added the channel ID and ledger to the function signature.

closes #113

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>