### PR TITLE
fix: ListInstalledChaincodesLegacy uses wrong directory

### DIFF
--- a/core/chaincode/persistence/mock/legacy_package_provider.go
+++ b/core/chaincode/persistence/mock/legacy_package_provider.go
@@ -23,6 +23,16 @@ type LegacyPackageProvider struct {
 		result1 []byte
 		result2 error
 	}
+	GetChaincodeInstallPathStub        func() string
+	getChaincodeInstallPathMutex       sync.RWMutex
+	getChaincodeInstallPathArgsForCall []struct {
+	}
+	getChaincodeInstallPathReturns struct {
+		result1 string
+	}
+	getChaincodeInstallPathReturnsOnCall map[int]struct {
+		result1 string
+	}
 	ListInstalledChaincodesStub        func(string, ccprovider.DirEnumerator, ccprovider.ChaincodeExtractor) ([]chaincode.InstalledChaincode, error)
 	listInstalledChaincodesMutex       sync.RWMutex
 	listInstalledChaincodesArgsForCall []struct {
@@ -106,6 +116,58 @@ func (fake *LegacyPackageProvider) GetChaincodeCodePackageReturnsOnCall(i int, r
 	}{result1, result2}
 }
 
+func (fake *LegacyPackageProvider) GetChaincodeInstallPath() string {
+	fake.getChaincodeInstallPathMutex.Lock()
+	ret, specificReturn := fake.getChaincodeInstallPathReturnsOnCall[len(fake.getChaincodeInstallPathArgsForCall)]
+	fake.getChaincodeInstallPathArgsForCall = append(fake.getChaincodeInstallPathArgsForCall, struct {
+	}{})
+	fake.recordInvocation("GetChaincodeInstallPath", []interface{}{})
+	fake.getChaincodeInstallPathMutex.Unlock()
+	if fake.GetChaincodeInstallPathStub != nil {
+		return fake.GetChaincodeInstallPathStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getChaincodeInstallPathReturns
+	return fakeReturns.result1
+}
+
+func (fake *LegacyPackageProvider) GetChaincodeInstallPathCallCount() int {
+	fake.getChaincodeInstallPathMutex.RLock()
+	defer fake.getChaincodeInstallPathMutex.RUnlock()
+	return len(fake.getChaincodeInstallPathArgsForCall)
+}
+
+func (fake *LegacyPackageProvider) GetChaincodeInstallPathCalls(stub func() string) {
+	fake.getChaincodeInstallPathMutex.Lock()
+	defer fake.getChaincodeInstallPathMutex.Unlock()
+	fake.GetChaincodeInstallPathStub = stub
+}
+
+func (fake *LegacyPackageProvider) GetChaincodeInstallPathReturns(result1 string) {
+	fake.getChaincodeInstallPathMutex.Lock()
+	defer fake.getChaincodeInstallPathMutex.Unlock()
+	fake.GetChaincodeInstallPathStub = nil
+	fake.getChaincodeInstallPathReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *LegacyPackageProvider) GetChaincodeInstallPathReturnsOnCall(i int, result1 string) {
+	fake.getChaincodeInstallPathMutex.Lock()
+	defer fake.getChaincodeInstallPathMutex.Unlock()
+	fake.GetChaincodeInstallPathStub = nil
+	if fake.getChaincodeInstallPathReturnsOnCall == nil {
+		fake.getChaincodeInstallPathReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.getChaincodeInstallPathReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *LegacyPackageProvider) ListInstalledChaincodes(arg1 string, arg2 ccprovider.DirEnumerator, arg3 ccprovider.ChaincodeExtractor) ([]chaincode.InstalledChaincode, error) {
 	fake.listInstalledChaincodesMutex.Lock()
 	ret, specificReturn := fake.listInstalledChaincodesReturnsOnCall[len(fake.listInstalledChaincodesArgsForCall)]
@@ -176,6 +238,8 @@ func (fake *LegacyPackageProvider) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.getChaincodeCodePackageMutex.RLock()
 	defer fake.getChaincodeCodePackageMutex.RUnlock()
+	fake.getChaincodeInstallPathMutex.RLock()
+	defer fake.getChaincodeInstallPathMutex.RUnlock()
 	fake.listInstalledChaincodesMutex.RLock()
 	defer fake.listInstalledChaincodesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/core/chaincode/persistence/package_provider.go
+++ b/core/chaincode/persistence/package_provider.go
@@ -26,6 +26,7 @@ type StorePackageProvider interface {
 // LegacyPackageProvider is the interface needed to retrieve
 // the code package from a ChaincodeDeploymentSpec
 type LegacyPackageProvider interface {
+	GetChaincodeInstallPath() string
 	GetChaincodeCodePackage(name, version string) (codePackage []byte, err error)
 	ListInstalledChaincodes(dir string, de ccprovider.DirEnumerator, ce ccprovider.ChaincodeExtractor) ([]chaincode.InstalledChaincode, error)
 }
@@ -99,7 +100,7 @@ func (p *PackageProvider) getCodePackageFromLegacyPP(name, version string) ([]by
 // ListInstalledChaincodesLegacy returns metadata (name, version, and ID) for
 // each chaincode installed on a peer with the legacy lifecycle
 func (p *PackageProvider) ListInstalledChaincodesLegacy() ([]chaincode.InstalledChaincode, error) {
-	installedChaincodesLegacy, err := p.LegacyPP.ListInstalledChaincodes(p.Store.GetChaincodeInstallPath(), ioutil.ReadDir, ccprovider.LoadPackage)
+	installedChaincodesLegacy, err := p.LegacyPP.ListInstalledChaincodes(p.LegacyPP.GetChaincodeInstallPath(), ioutil.ReadDir, ccprovider.LoadPackage)
 	if err != nil {
 		return nil, err
 	}

--- a/core/common/ccprovider/ccprovider.go
+++ b/core/common/ccprovider/ccprovider.go
@@ -151,6 +151,11 @@ func (*CCInfoFSImpl) GetChaincodeFromPath(ccname string, ccversion string, path 
 	return cccdspack, nil
 }
 
+// GetChaincodeInstallPath returns the path to the installed chaincodes
+func (*CCInfoFSImpl) GetChaincodeInstallPath() string {
+	return chaincodeInstallPath
+}
+
 // PutChaincodeIntoFS is a wrapper for putting raw ChaincodeDeploymentSpec
 //using CDSPackage. This is only used in UTs
 func (*CCInfoFSImpl) PutChaincode(depSpec *pb.ChaincodeDeploymentSpec) (CCPackage, error) {

--- a/core/common/ccprovider/ccprovider_test.go
+++ b/core/common/ccprovider/ccprovider_test.go
@@ -128,6 +128,15 @@ func TestChaincodeData(t *testing.T) {
 	assert.Equal(t, po, []byte("Policy"))
 }
 
+func TestGetChaincodeInstallPath(t *testing.T) {
+	c := &ccprovider.CCInfoFSImpl{}
+	installPath := c.GetChaincodeInstallPath()
+	defer ccprovider.SetChaincodesPath(installPath)
+
+	ccprovider.SetChaincodesPath("blahblah")
+	assert.Equal(t, "blahblah", c.GetChaincodeInstallPath())
+}
+
 func setupDirectoryStructure(t *testing.T) (string, map[string][]byte) {
 	files := []string{
 		"example02.1.0", // Version contains the delimiter '.' is a valid case

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -210,6 +210,10 @@ func serve(args []string) error {
 		Parser:   ccPackageParser,
 	}
 
+	// Configure CC package storage
+	lsccInstallPath := filepath.Join(coreconfig.GetPath("peer.fileSystemPath"), "chaincodes")
+	ccprovider.SetChaincodesPath(lsccInstallPath)
+
 	// legacyMetadataManager collects metadata information from the legacy
 	// lifecycle (lscc). This is expected to disappear with FAB-15061.
 	legacyMetadataManager, err := cclifecycle.NewMetadataManager(
@@ -269,10 +273,6 @@ func serve(args []string) error {
 			CollDataProvider:                collDataProvider,
 		},
 	)
-
-	// Configure CC package storage
-	lsccInstallPath := filepath.Join(coreconfig.GetPath("peer.fileSystemPath"), "chaincodes")
-	ccprovider.SetChaincodesPath(lsccInstallPath)
 
 	if err := lifecycleCache.InitializeLocalChaincodes(); err != nil {
 		return errors.WithMessage(err, "could not initialize local chaincodes")


### PR DESCRIPTION
Copied fix from https://github.com/hyperledger/fabric/commit/87f303601642aa7f6b59db6e76d080c99f1e1519#diff-82d1c74dbfebf3e96f5ec3e5b0333dbe.

closes #118

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>