### PR TITLE
chore: Rename viper to oldviper

### DIFF
--- a/bccsp/factory/factory_test.go
+++ b/bccsp/factory/factory_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric/bccsp/pkcs11"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/peer/main.go
+++ b/cmd/peer/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hyperledger/fabric/internal/peer/node"
 	"github.com/hyperledger/fabric/internal/peer/version"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // The main command describes the service and

--- a/common/viperutil/config_test.go
+++ b/common/viperutil/config_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/hyperledger/fabric/orderer/mocks/util"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 const Prefix = "VIPERUTIL"

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -22,7 +22,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/mitchellh/mapstructure"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 var logger = flogging.MustGetLogger("viperutil")

--- a/core/chaincode/config.go
+++ b/core/chaincode/config.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/op/go-logging"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 const (

--- a/core/chaincode/config_test.go
+++ b/core/chaincode/config_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 var _ = Describe("Config", func() {

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -61,7 +61,7 @@ import (
 	"github.com/hyperledger/fabric/protos/common"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protoutil"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"

--- a/core/chaincode/executetransaction_pvtdata_test.go
+++ b/core/chaincode/executetransaction_pvtdata_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/protos/common"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -24,7 +24,7 @@ import (
 	cutil "github.com/hyperledger/fabric/core/container/util"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // Platform for chaincodes written in Go

--- a/core/chaincode/platforms/golang/platform_test.go
+++ b/core/chaincode/platforms/golang/platform_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/platforms/util"
 	"github.com/hyperledger/fabric/core/config/configtest"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/core/chaincode/platforms/java/platform_test.go
+++ b/core/chaincode/platforms/java/platform_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/platforms/util"
 	"github.com/hyperledger/fabric/core/config/configtest"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/core/chaincode/platforms/node/platform_test.go
+++ b/core/chaincode/platforms/node/platform_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/chaincode/platforms/util"
 	"github.com/hyperledger/fabric/core/config/configtest"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/chaincode/platforms/platforms_test.go
+++ b/core/chaincode/platforms/platforms_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/platforms/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 var _ = Describe("Platforms", func() {

--- a/core/chaincode/platforms/util/utils.go
+++ b/core/chaincode/platforms/util/utils.go
@@ -16,7 +16,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/metadata"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 var logger = flogging.MustGetLogger("chaincode.platform.util")

--- a/core/chaincode/platforms/util/utils_test.go
+++ b/core/chaincode/platforms/util/utils_test.go
@@ -19,7 +19,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hyperledger/fabric/common/metadata"
 	"github.com/hyperledger/fabric/core/config/configtest"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 func dirExists(path string) bool {

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/config/configtest/config.go
+++ b/core/config/configtest/config.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/config/configtest/config_test.go
+++ b/core/config/configtest/config_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric/core/config/configtest"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/deliverservice/deliveryclient.go
+++ b/core/deliverservice/deliveryclient.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/util"
 	"github.com/hyperledger/fabric/internal/pkg/identity"
 	"github.com/hyperledger/fabric/protos/orderer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"google.golang.org/grpc"
 )
 

--- a/core/deliverservice/deliveryclient_test.go
+++ b/core/deliverservice/deliveryclient_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/api"
 	"github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/protos/orderer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/core/ledger/kvledger/idstore/test_exports.go
+++ b/core/ledger/kvledger/idstore/test_exports.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 
 	coreconfig "github.com/hyperledger/fabric/core/config"
 	"github.com/stretchr/testify/require"

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hyperledger/fabric/core/comm"
 	"github.com/hyperledger/fabric/core/config"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // Config is the struct that defines the Peer configurations.

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/fabric/core/comm"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/peer/peer_test.go
+++ b/core/peer/peer_test.go
@@ -16,7 +16,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 
 	configtxtest "github.com/hyperledger/fabric/common/configtx/test"
 	"github.com/hyperledger/fabric/common/metrics/disabled"

--- a/core/peer/pkg_test.go
+++ b/core/peer/pkg_test.go
@@ -32,7 +32,7 @@ import (
 	cb "github.com/hyperledger/fabric/protos/common"
 	mspproto "github.com/hyperledger/fabric/protos/msp"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"

--- a/core/scc/cscc/configure_test.go
+++ b/core/scc/cscc/configure_test.go
@@ -47,7 +47,7 @@ import (
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"

--- a/core/scc/loadsysccs_test.go
+++ b/core/scc/loadsysccs_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/core/scc/lscc/lscc_test.go
+++ b/core/scc/lscc/lscc_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/cauthdsl"

--- a/core/scc/qscc/query_test.go
+++ b/core/scc/qscc/query_test.go
@@ -24,7 +24,7 @@ import (
 	peer2 "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/core/scc/scc_test.go
+++ b/core/scc/scc_test.go
@@ -15,7 +15,7 @@ import (
 	ccprovider2 "github.com/hyperledger/fabric/core/mocks/ccprovider"
 	"github.com/hyperledger/fabric/core/peer"
 	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/scc/whitelist.go
+++ b/core/scc/whitelist.go
@@ -9,7 +9,7 @@ package scc
 import (
 	"strings"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // Whitelist termintes if a named system chaincode is enabled to run in this peer.

--- a/core/scc/whitelist_test.go
+++ b/core/scc/whitelist_test.go
@@ -9,7 +9,7 @@ package scc
 import (
 	"testing"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/testutil/config.go
+++ b/core/testutil/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/config/configtest"
 	"github.com/hyperledger/fabric/msp"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 var configLogger = flogging.MustGetLogger("config")

--- a/core/transientstore/store_test.go
+++ b/core/transientstore/store_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/hyperledger/fabric/protos/transientstore"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/extensions/go.mod
+++ b/extensions/go.mod
@@ -7,6 +7,8 @@ replace github.com/hyperledger/fabric/extensions => ./
 require (
 	github.com/hyperledger/fabric v1.4.0
 	github.com/pkg/errors v0.8.1
-	github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
+	github.com/spf13/oldviper v0.0.0
 	github.com/stretchr/testify v1.3.0
 )
+
+replace github.com/spf13/oldviper => github.com/spf13/viper v0.0.0-20150908122457-1967d93db724

--- a/extensions/storage/blkstorage/store_test.go
+++ b/extensions/storage/blkstorage/store_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hyperledger/fabric/common/ledger/blkstorage"
 	coreconfig "github.com/hyperledger/fabric/core/config"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/require"
 )
 

--- a/extensions/storage/idstore/store_test.go
+++ b/extensions/storage/idstore/store_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hyperledger/fabric/extensions/testutil"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 
 	"github.com/stretchr/testify/require"
 )

--- a/extensions/storage/pvtdatastorage/store_test.go
+++ b/extensions/storage/pvtdatastorage/store_test.go
@@ -16,7 +16,7 @@ import (
 
 	coreconfig "github.com/hyperledger/fabric/core/config"
 	"github.com/hyperledger/fabric/core/ledger"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/require"
 )
 

--- a/extensions/storage/transientstore/store_test.go
+++ b/extensions/storage/transientstore/store_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -38,8 +38,8 @@ require (
 	github.com/spf13/cast v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/oldviper v0.0.0
 	github.com/spf13/pflag v1.0.3
-	github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
 	github.com/stretchr/testify v1.3.0
 	github.com/sykesm/zap-logfmt v0.0.2
 	github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965
@@ -65,3 +65,5 @@ replace github.com/docker/libnetwork => github.com/docker/libnetwork v0.0.0-2018
 replace github.com/docker/docker => github.com/docker/docker v0.0.0-20180827131323-0c5f8d2b9b23
 
 replace github.com/hyperledger/fabric/extensions => ./extensions
+
+replace github.com/spf13/oldviper => github.com/spf13/viper v0.0.0-20150908122457-1967d93db724

--- a/gossip/integration/integration.go
+++ b/gossip/integration/integration.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/metrics"
 	"github.com/hyperledger/fabric/gossip/util"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"google.golang.org/grpc"
 )
 

--- a/gossip/integration/integration_test.go
+++ b/gossip/integration/integration_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/util"
 	"github.com/hyperledger/fabric/msp/mgmt"
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/gossip/privdata/util.go
+++ b/gossip/privdata/util.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric/protos/msp"
 	"github.com/hyperledger/fabric/protos/peer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 type txValidationFlags []uint8

--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"google.golang.org/grpc"
 )
 

--- a/gossip/service/integration_test.go
+++ b/gossip/service/integration_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/util"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	transientstore2 "github.com/hyperledger/fabric/protos/transientstore"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // GossipStateProvider is the interface to acquire sequences of the ledger blocks

--- a/gossip/util/misc.go
+++ b/gossip/util/misc.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // Equals returns whether a and b are the same

--- a/gossip/util/misc_test.go
+++ b/gossip/util/misc_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/integration/pluggable/plugin_activation.go
+++ b/integration/pluggable/plugin_activation.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 const (

--- a/internal/configtxgen/localconfig/config.go
+++ b/internal/configtxgen/localconfig/config.go
@@ -18,7 +18,7 @@ import (
 	cf "github.com/hyperledger/fabric/core/config"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/protos/orderer/etcdraft"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 const (

--- a/internal/peer/chaincode/common.go
+++ b/internal/peer/chaincode/common.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // checkSpec to see if chaincode resides within current package capture for language.

--- a/internal/peer/chaincode/common_test.go
+++ b/internal/peer/chaincode/common_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/peer/chaincode/flags_test.go
+++ b/internal/peer/chaincode/flags_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hyperledger/fabric/internal/peer/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/chaincode/install_test.go
+++ b/internal/peer/chaincode/install_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger/fabric/internal/peer/common"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/chaincode/invoke_test.go
+++ b/internal/peer/chaincode/invoke_test.go
@@ -21,7 +21,7 @@ import (
 	cb "github.com/hyperledger/fabric/protos/common"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protoutil"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/internal/peer/chaincode/upgrade_test.go
+++ b/internal/peer/chaincode/upgrade_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hyperledger/fabric/internal/peer/common"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/channel/create_test.go
+++ b/internal/peer/channel/create_test.go
@@ -27,7 +27,7 @@ import (
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
 	cb "github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/orderer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/internal/peer/channel/fetch_test.go
+++ b/internal/peer/channel/fetch_test.go
@@ -20,7 +20,7 @@ import (
 	cb "github.com/hyperledger/fabric/protos/common"
 	ab "github.com/hyperledger/fabric/protos/orderer"
 	"github.com/hyperledger/fabric/protoutil"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/channel/flags_test.go
+++ b/internal/peer/channel/flags_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hyperledger/fabric/internal/peer/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/channel/join_test.go
+++ b/internal/peer/channel/join_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hyperledger/fabric/internal/peer/common"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -30,7 +30,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // UndefinedParamValue defines what undefined parameters in the command line will initialise to

--- a/internal/peer/common/common_test.go
+++ b/internal/peer/common/common_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric/core/config/configtest"
 	"github.com/hyperledger/fabric/internal/peer/common"
 	"github.com/hyperledger/fabric/msp"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/common/deliverclient_test.go
+++ b/internal/peer/common/deliverclient_test.go
@@ -18,7 +18,7 @@ import (
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
 	cb "github.com/hyperledger/fabric/protos/common"
 	ab "github.com/hyperledger/fabric/protos/orderer"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/common/ordererclient_test.go
+++ b/internal/peer/common/ordererclient_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/comm"
 	"github.com/hyperledger/fabric/internal/peer/common"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/common/ordererenv.go
+++ b/internal/peer/common/ordererenv.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 var (

--- a/internal/peer/common/ordererenv_test.go
+++ b/internal/peer/common/ordererenv_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hyperledger/fabric/internal/peer/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/common/peerclient_test.go
+++ b/internal/peer/common/peerclient_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/comm"
 	"github.com/hyperledger/fabric/internal/peer/common"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/lifecycle/chaincode/approveformyorg.go
+++ b/internal/peer/lifecycle/chaincode/approveformyorg.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // ApproverForMyOrg holds the dependencies needed to approve

--- a/internal/peer/lifecycle/chaincode/client_connections.go
+++ b/internal/peer/lifecycle/chaincode/client_connections.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hyperledger/fabric/internal/pkg/identity"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // ClientConnections holds the clients for connecting to the various

--- a/internal/peer/lifecycle/chaincode/commit.go
+++ b/internal/peer/lifecycle/chaincode/commit.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // Committer holds the dependencies needed to commit

--- a/internal/peer/lifecycle/chaincode/install.go
+++ b/internal/peer/lifecycle/chaincode/install.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // Reader defines the interface needed for reading a file.

--- a/internal/peer/lifecycle/chaincode/queryapprovalstatus.go
+++ b/internal/peer/lifecycle/chaincode/queryapprovalstatus.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 var chaincodeQueryApprovalStatusCmd *cobra.Command

--- a/internal/peer/lifecycle/chaincode/querycommitted.go
+++ b/internal/peer/lifecycle/chaincode/querycommitted.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // CommittedQuerier holds the dependencies needed to query

--- a/internal/peer/lifecycle/chaincode/queryinstalled.go
+++ b/internal/peer/lifecycle/chaincode/queryinstalled.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // InstalledQuerier holds the dependencies needed to query

--- a/internal/peer/node/config.go
+++ b/internal/peer/node/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
 
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 func ledgerConfig() *ledger.Config {

--- a/internal/peer/node/config_test.go
+++ b/internal/peer/node/config_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -91,7 +91,7 @@ import (
 	"github.com/hyperledger/fabric/token/tms/manager"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"google.golang.org/grpc"
 )
 

--- a/internal/peer/node/start_test.go
+++ b/internal/peer/node/start_test.go
@@ -19,7 +19,7 @@ import (
 	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/internal/peer/node/status_test.go
+++ b/internal/peer/node/status_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/fabric/msp"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protoutil"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/msp/mgmt/mgmt.go
+++ b/msp/mgmt/mgmt.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/msp/cache"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // LoadLocalMspWithType loads the local MSP with the specified type from the specified directory

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/viperutil"
 	coreconfig "github.com/hyperledger/fabric/core/config"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 )
 
 // Prefix for environment variables.

--- a/peer/node/common_test.go
+++ b/peer/node/common_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/config/configtest"
 	"github.com/hyperledger/fabric/internal/peer/common"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/peer/node/main_test.go
+++ b/peer/node/main_test.go
@@ -13,7 +13,7 @@ import (
 
 	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
-	"github.com/spf13/viper"
+	viper "github.com/spf13/oldviper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"


### PR DESCRIPTION
The version of viper currently used in fabric is 5 years old. It prevents integration with any library that requires a newer version of viper.
This patch renames viper to 'oldviper' to allow for integration with libraries that use a newer version.

closes #122

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>