### PR TITLE
feat: Initialize resources before system chaincodes

### DIFF
--- a/extensions/gossip/api/gossipapi.go
+++ b/extensions/gossip/api/gossipapi.go
@@ -79,3 +79,8 @@ type Support struct {
 	LedgerHeightProvider LedgerHeightProvider
 	BlockEventer         BlockEventer
 }
+
+// GossipService contains Gossip function
+type GossipService interface {
+	// It's up to extensions which functions are exposed
+}

--- a/internal/peer/node/providers.go
+++ b/internal/peer/node/providers.go
@@ -9,12 +9,21 @@ package node
 import (
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/peer"
+	"github.com/hyperledger/fabric/extensions/gossip/api"
 	"github.com/hyperledger/fabric/gossip/service"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/msp/mgmt"
 )
 
-func newGossipProvider() service.GossipService {
+type gossipProvider struct {
+}
+
+func newGossipProvider() *gossipProvider {
+	return &gossipProvider{}
+}
+
+// GetGossipService returns the Gossip service
+func (p *gossipProvider) GetGossipService() api.GossipService {
 	return service.GetGossipService()
 }
 


### PR DESCRIPTION
Resources are initialized before external system chaincodes so that a system chaincode can be injected with dependent resources.

Because of this change, the Gossip resource was also changed to a Gossip provider in order to defer the retrieval of the service (since the resource is initialized before Gossip).

closes # 135

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>