### PR TITLE
fix: Fix for TestPluginLoadingFailure

### DIFF
--- a/cmd/peer/main_test.go
+++ b/cmd/peer/main_test.go
@@ -26,7 +26,7 @@ func TestPluginLoadingFailure(t *testing.T) {
 	addr, _, destroy := xtestutil.SetupExtTestEnv()
 	defer destroy()
 	gt := NewGomegaWithT(t)
-	peer, err := gexec.Build("github.com/hyperledger/fabric/cmd/peer")
+	peer, err := gexec.Build("github.com/hyperledger/fabric/cmd/peer", "-tags", "testing")
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 

--- a/cmd/peer/test_init.go
+++ b/cmd/peer/test_init.go
@@ -1,0 +1,18 @@
+// +build testing
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	xtestutil "github.com/hyperledger/fabric/extensions/testutil"
+)
+
+// init is only executed for the unit test
+func init() {
+	xtestutil.SetupResources()
+}

--- a/extensions/testutil/ext_test_env.go
+++ b/extensions/testutil/ext_test_env.go
@@ -24,6 +24,13 @@ func SetupExtTestEnv() (addr string, cleanup func(string), stop func()) {
 		}
 }
 
+// SetupResources sets up all of the mock resource providers
+func SetupResources() func() {
+	return func() {
+		//do nothing
+	}
+}
+
 func GetExtStateDBProvider(t testing.TB, dbProvider statedb.VersionedDBProvider) statedb.VersionedDBProvider {
 	return nil
 }

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -183,8 +183,8 @@ func TestLeaderElectionWithDeliverClient(t *testing.T) {
 }
 
 func TestWithStaticDeliverClientLeader(t *testing.T) {
-	_, _, destroy := xtestutil.SetupExtTestEnv()
-	defer destroy()
+	clearResources := xtestutil.SetupResources()
+	defer clearResources()
 
 	//Tests check if static leader flag works ok.
 	//Leader election flag set to false, and static leader flag set to true


### PR DESCRIPTION
Add an init() that is invoked only if build tag 'testing' is set and build the command with this tag. The init() func initializes all resource providers.

closes #139

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>