### PR TITLE
fix: Don't perform recovery if not committer

### DIFF
--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/ledgerstorage"
 	"github.com/hyperledger/fabric/core/ledger/pvtdatastorage"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	"github.com/hyperledger/fabric/extensions/roles"
 	storageapi "github.com/hyperledger/fabric/extensions/storage/api"
 	idstoreext "github.com/hyperledger/fabric/extensions/storage/idstore"
 	"github.com/hyperledger/fabric/protoutil"
@@ -124,7 +125,9 @@ func NewProvider(initializer *ledger.Initializer) (pr *Provider, e error) {
 
 	p.initLedgerStatistics()
 
-	p.recoverUnderConstructionLedger()
+	if roles.IsCommitter() {
+		p.recoverUnderConstructionLedger()
+	}
 
 	p.collDataProvider = initializer.CollDataProvider
 


### PR DESCRIPTION
On peer startup, the committer sets the 'under construction' flag while initializing the DB. A non-committing peer would detect the 'under construction' flag and attempt recovery. This results in a panic.
This fix disables recovery for non-committing peers.

closes #152
