### PR TITLE
fix: Panic when retrieving collection config for non-existent chaincode

### DIFF
--- a/ci/azure-pipelines-mod.yml
+++ b/ci/azure-pipelines-mod.yml
@@ -27,7 +27,7 @@ jobs:
     pool:
       vmImage: ubuntu-18.04
     strategy:
-      parallel: 6
+      parallel: 7
     timeoutInMinutes: 240
     steps:
     - template: azp-dependencies-mod.yml

--- a/core/chaincode/lifecycle/deployedcc_infoprovider.go
+++ b/core/chaincode/lifecycle/deployedcc_infoprovider.go
@@ -88,7 +88,11 @@ func (vc *ValidatorCommitter) ChaincodeInfo(channelName, chaincodeName string, q
 	}
 
 	if !exists {
-		return vc.LegacyDeployedCCInfoProvider.ChaincodeInfo(channelName, chaincodeName, qe)
+		ccInfo, err := vc.LegacyDeployedCCInfoProvider.ChaincodeInfo(channelName, chaincodeName, qe)
+		if err != nil || ccInfo == nil {
+			return &ledger.DeployedChaincodeInfo{}, err
+		}
+		return ccInfo, err
 	}
 
 	return &ledger.DeployedChaincodeInfo{

--- a/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
+++ b/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
@@ -199,11 +199,7 @@ var _ = Describe("ValidatorCommitter", func() {
 
 			It("passes through to the legacy impl", func() {
 				res, err := vc.ChaincodeInfo("channel-name", "legacy-name", fakeQueryExecutor)
-				Expect(res).To(Equal(&ledger.DeployedChaincodeInfo{
-					Name:    "legacy-name",
-					Hash:    []byte("hash"),
-					Version: "cc-version",
-				}))
+				Expect(res).To(Equal(&ledger.DeployedChaincodeInfo{}))
 				Expect(err).To(MatchError("chaincode-info-error"))
 				Expect(fakeLegacyProvider.ChaincodeInfoCallCount()).To(Equal(1))
 				channelID, ccName, qe := fakeLegacyProvider.ChaincodeInfoArgsForCall(0)


### PR DESCRIPTION
Check for nil from legacy chaincode info provider and return an empty ChaincodeInfo struct, otherwise a panic results.

closes #156

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
