### PR TITLE
fix: Register legacy and in-process changecodes on startup

### DIFF
--- a/core/cclifecycle/subscription.go
+++ b/core/cclifecycle/subscription.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger/fabric/common/chaincode"
 	"github.com/hyperledger/fabric/core/ledger/cceventmgmt"
+	extucc "github.com/hyperledger/fabric/extensions/chaincode"
 )
 
 // Subscription channels information flow
@@ -93,6 +94,12 @@ func queryChaincodeDefinitions(query Query, installedCCs []chaincode.InstalledCh
 	}
 
 	filter := func(cc chaincode.Metadata) bool {
+		_, exists := extucc.GetUCC(cc.Name)
+		if exists {
+			Logger.Debugf("Accepting chaincode [%s] since it's an in-process user chaincode", cc.Name)
+			return true
+		}
+
 		installedID, exists := installedCCsToIDs[deployedCCToNameVersion(cc)]
 		if !exists {
 			Logger.Debug("Chaincode", cc, "is instantiated but a different version is installed")

--- a/extensions/chaincode/ucc.go
+++ b/extensions/chaincode/ucc.go
@@ -14,3 +14,12 @@ import (
 func GetUCC(ccID string) (api.UserCC, bool) {
 	return nil, false
 }
+
+// Chaincodes returns all registered in-process chaincodes
+func Chaincodes() []api.UserCC {
+	return nil
+}
+
+// WaitForReady blocks until the chaincodes are all registered
+func WaitForReady() {
+}


### PR DESCRIPTION
After a restart, legacy chaincodes were not being registered since the chaincode directory path was not set. Also, in-process chaincodes were not being registered.
This patch sets the legacy chaincode path and adds all in-process chaincodes to the CC meta data.

closes #161

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
