### PR TITLE
fix: Panic when checking DB data version

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
+	"github.com/hyperledger/fabric/extensions/roles"
 	xcouchdb "github.com/hyperledger/fabric/extensions/storage/couchdb"
 	xstatedb "github.com/hyperledger/fabric/extensions/storage/statedb"
 	"github.com/pkg/errors"
@@ -54,9 +55,13 @@ func NewVersionedDBProvider(config *couchdb.Config, metricsProvider metrics.Prov
 	if err != nil {
 		return nil, err
 	}
-	if err := checkExpectedDataformatVersion(couchInstance); err != nil {
-		return nil, err
+
+	if roles.IsCommitter() {
+		if err := checkExpectedDataformatVersion(couchInstance); err != nil {
+			return nil, err
+		}
 	}
+
 	p, err := newRedoLoggerProvider(config.RedoLogPath)
 	if err != nil {
 		return nil, err

--- a/core/ledger/util/couchdb/couchdb.go
+++ b/core/ledger/util/couchdb/couchdb.go
@@ -453,7 +453,7 @@ func (couchInstance *CouchInstance) VerifyCouchConfig() (*ConnectionInfo, *DBRet
 func (couchInstance *CouchInstance) IsEmpty(databasesToIgnore []string) (bool, error) {
 	toIgnore := map[string]bool{}
 	for _, s := range databasesToIgnore {
-		toIgnore[s] = true
+		toIgnore[dbname.Resolve(s)] = true
 	}
 	applicationDBNames, err := couchInstance.RetrieveApplicationDBNames()
 	if err != nil {
@@ -503,10 +503,13 @@ func (couchInstance *CouchInstance) RetrieveApplicationDBNames() ([]string, erro
 	logger.Debugf("dbNames = %s", dbNames)
 	applicationsDBNames := []string{}
 	for _, d := range dbNames {
-		if !isCouchSystemDBName(d) {
+		if !isCouchSystemDBName(d) && dbname.IsRelevant(d) {
 			applicationsDBNames = append(applicationsDBNames, d)
 		}
 	}
+
+	logger.Debugf("Returning application DB names: %s", applicationsDBNames)
+
 	return applicationsDBNames, nil
 }
 

--- a/extensions/storage/dbname/resolver.go
+++ b/extensions/storage/dbname/resolver.go
@@ -10,3 +10,10 @@ package dbname
 func Resolve(dbName string) string {
 	return dbName
 }
+
+// IsRelevant returns true if the given database is relevant to this peer. If the database is shared
+// by multiple peers then it may not be relevant to this peer.
+// This default implementation simply returns true.
+func IsRelevant(dbName string) bool {
+	return true
+}

--- a/extensions/storage/dbname/resolver_test.go
+++ b/extensions/storage/dbname/resolver_test.go
@@ -17,3 +17,7 @@ func TestResolve(t *testing.T) {
 
 	require.Equal(t, dbName, Resolve(dbName))
 }
+
+func TestIsRelevant(t *testing.T) {
+	require.True(t, IsRelevant("somedb"))
+}


### PR DESCRIPTION
Multiple problems were fixed when checking for DB data version:
- A race condition exists in clustered mode when checking/writing the data version to the DB. Only a committer should be writing the data version.
- When using DB partitions, ensure that the DB name is encoded properly before adding to the ignore list.
- Do not examine databases that are not relevant to the peer (in the case of a shared database).

closes #175

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
