### PR TITLE
feat: Get DB artifacts for specified collections

### DIFF
--- a/extensions/chaincode/api/api.go
+++ b/extensions/chaincode/api/api.go
@@ -19,6 +19,9 @@ type DBArtifacts struct {
 // UserCC contains information about an in-process user chaincode
 type UserCC interface {
 	scc.SelfDescribingSysCC
+
+	// Version returns the version of this chaincode
 	Version() string
-	GetDBArtifacts() map[string]*DBArtifacts
+	// GetDBArtifacts returns the DB artifacts for this chaincode along with those of the given collections
+	GetDBArtifacts(collNames []string) map[string]*DBArtifacts
 }

--- a/extensions/chaincode/mock/usercc.gen.go
+++ b/extensions/chaincode/mock/usercc.gen.go
@@ -36,10 +36,12 @@ type UserCC struct {
 	versionReturnsOnCall map[int]struct {
 		result1 string
 	}
-	GetDBArtifactsStub        func() map[string]*api.DBArtifacts
+	GetDBArtifactsStub        func(collNames []string) map[string]*api.DBArtifacts
 	getDBArtifactsMutex       sync.RWMutex
-	getDBArtifactsArgsForCall []struct{}
-	getDBArtifactsReturns     struct {
+	getDBArtifactsArgsForCall []struct {
+		collNames []string
+	}
+	getDBArtifactsReturns struct {
 		result1 map[string]*api.DBArtifacts
 	}
 	getDBArtifactsReturnsOnCall map[int]struct {
@@ -169,14 +171,21 @@ func (fake *UserCC) VersionReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *UserCC) GetDBArtifacts() map[string]*api.DBArtifacts {
+func (fake *UserCC) GetDBArtifacts(collNames []string) map[string]*api.DBArtifacts {
+	var collNamesCopy []string
+	if collNames != nil {
+		collNamesCopy = make([]string, len(collNames))
+		copy(collNamesCopy, collNames)
+	}
 	fake.getDBArtifactsMutex.Lock()
 	ret, specificReturn := fake.getDBArtifactsReturnsOnCall[len(fake.getDBArtifactsArgsForCall)]
-	fake.getDBArtifactsArgsForCall = append(fake.getDBArtifactsArgsForCall, struct{}{})
-	fake.recordInvocation("GetDBArtifacts", []interface{}{})
+	fake.getDBArtifactsArgsForCall = append(fake.getDBArtifactsArgsForCall, struct {
+		collNames []string
+	}{collNamesCopy})
+	fake.recordInvocation("GetDBArtifacts", []interface{}{collNamesCopy})
 	fake.getDBArtifactsMutex.Unlock()
 	if fake.GetDBArtifactsStub != nil {
-		return fake.GetDBArtifactsStub()
+		return fake.GetDBArtifactsStub(collNames)
 	}
 	if specificReturn {
 		return ret.result1
@@ -188,6 +197,12 @@ func (fake *UserCC) GetDBArtifactsCallCount() int {
 	fake.getDBArtifactsMutex.RLock()
 	defer fake.getDBArtifactsMutex.RUnlock()
 	return len(fake.getDBArtifactsArgsForCall)
+}
+
+func (fake *UserCC) GetDBArtifactsArgsForCall(i int) []string {
+	fake.getDBArtifactsMutex.RLock()
+	defer fake.getDBArtifactsMutex.RUnlock()
+	return fake.getDBArtifactsArgsForCall[i].collNames
 }
 
 func (fake *UserCC) GetDBArtifactsReturns(result1 map[string]*api.DBArtifacts) {


### PR DESCRIPTION
The signature of function, GetDBArtifacts, was changed such that the names of the collections for the chaincode are passed in as an argument. The in-process user chaincode decides which indexes should be returned for each collection. This allows for the names of the collections and the number of collections to be dynamic.

closes #179