### PR TITLE
fix: Call extension AddPayload when receiving a block from Gossip

### DIFF
--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -323,7 +323,7 @@ func (s *GossipStateProviderImpl) receiveAndQueueGossipMessages(ch <-chan *proto
 
 			dataMsg := msg.GetDataMsg()
 			if dataMsg != nil {
-				if err := s.addPayload(dataMsg.GetPayload(), nonBlocking); err != nil {
+				if err := s.extension.AddPayload(s.addPayload)(dataMsg.GetPayload(), s.blockingMode); err != nil {
 					logger.Warningf("Block [%d] received from gossip wasn't added to payload buffer: %v", dataMsg.Payload.SeqNum, err)
 					return
 				}


### PR DESCRIPTION
The extension function, AddPayload, should be called so that it can apply custom logic when adding a block (payload).

closes #181

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
