### PR TITLE
feat: Hooks for loading Auth Filters and Decorators

### DIFF
--- a/core/handlers/library/extensions.go
+++ b/core/handlers/library/extensions.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package library
+
+import (
+	"github.com/hyperledger/fabric/extensions/handlers"
+)
+
+// loadExtension attempts to load the handler from extensions and returns true if the handler was found; false otherwise
+func (r *registry) loadExtension(handlerFactory string, handlerType HandlerType, extraArgs ...string) bool {
+	if handlerType == Auth {
+		if f := handlers.GetAuthFilter(handlerFactory); f != nil {
+			r.filters = append(r.filters, f)
+			return true
+		}
+	} else if handlerType == Decoration {
+		if d := handlers.GetDecorator(handlerFactory); d != nil {
+			r.decorators = append(r.decorators, d)
+			return true
+		}
+	}
+
+	return false
+}

--- a/core/handlers/library/extensions_test.go
+++ b/core/handlers/library/extensions_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package library
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_LoadExtensions(t *testing.T) {
+	testReg := registry{}
+	require.False(t, testReg.loadExtension("handler1", Auth))
+	require.False(t, testReg.loadExtension("handler1", Decoration))
+	require.False(t, testReg.loadExtension("handler1", Endorsement))
+	require.False(t, testReg.loadExtension("handler1", Validation))
+}

--- a/extensions/handlers/handlers.go
+++ b/extensions/handlers/handlers.go
@@ -1,0 +1,24 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package handlers
+
+import (
+	"github.com/hyperledger/fabric/core/handlers/auth"
+	"github.com/hyperledger/fabric/core/handlers/decoration"
+)
+
+// GetAuthFilter allows extensions to load an Auth filter.
+// Returns the Auth filter if found; nil otherwise
+func GetAuthFilter(name string) auth.Filter {
+	return nil
+}
+
+// GetDecorator allows extensions to load a Decorator.
+// Returns the Decorator if found; nil otherwise
+func GetDecorator(name string) decoration.Decorator {
+	return nil
+}

--- a/extensions/handlers/handlers_test.go
+++ b/extensions/handlers/handlers_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAuthFilter(t *testing.T) {
+	require.Nil(t, GetAuthFilter("handler"))
+}
+
+func TestGetDecorator(t *testing.T) {
+	require.Nil(t, GetDecorator("handler"))
+}

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -682,7 +682,6 @@ func serve(args []string) error {
 
 	reg := library.InitRegistry(libConf)
 
-	authFilters := reg.Lookup(library.Auth).([]authHandler.Filter)
 	endorserSupport := &endorser.SupportImpl{
 		SignerSerializer: signingIdentity,
 		Peer:             peerInstance,
@@ -881,6 +880,7 @@ func serve(args []string) error {
 		logger.Infof("Ledger rebuild: channel [%s]: preresetHeight: [%d]", cid, height)
 	}
 
+	authFilters := reg.Lookup(library.Auth).([]authHandler.Filter)
 	if len(preResetHeights) > 0 {
 		logger.Info("Ledger rebuild: Entering loop to check if current ledger heights surpass prereset ledger heights. Endorsement request processing will be disabled.")
 		resetFilter := &reset{


### PR DESCRIPTION
Added hooks to allow extensions to load Auth filters and Decorators using an alternative mechanism (other than Go plugins).

The handler registry was changed to perform lazy loading of handlers since the auth handlers were being loaded before the auth handler extensions were registered.

closes #185

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
