### PR TITLE
fix: Add external SCCs to built-in SCC list

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -741,6 +741,11 @@ func serve(args []string) error {
 	chaincodes = append(chaincodes, lsccInst, csccInst, qsccInst, lifecycleSCC)
 	chaincodes = append(chaincodes, extscc...)
 
+	for _, cc := range extscc {
+		logger.Debugf("Adding external system chaincode to the list of built-in system chaincodes [%s]", cc.Name())
+		builtinSCCs[cc.Name()] = struct{}{}
+	}
+
 	// deploy system chaincodes
 	for _, cc := range chaincodes {
 		if enabled, ok := chaincodeConfig.SCCWhitelist[cc.Name()]; !ok || !enabled {


### PR DESCRIPTION
Added external system chaincodes to the list of built-in system chaincodes so that they aren't prevented from being invoked.

closes #189

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
