### PR TITLE
chore: Register lifecycle.ValidatorCommitter as a resource

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -747,6 +747,7 @@ func serve(args []string) error {
 		plugin.MapBasedMapper(validationPluginsByName),
 		aclProvider,
 		endorserSupport,
+		lifecycleValidatorCommitter,
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
closes #242

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>
