### PR TITLE
feat: Register chaincode cache as a resource

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -748,6 +748,7 @@ func serve(args []string) error {
 		aclProvider,
 		endorserSupport,
 		lifecycleValidatorCommitter,
+		lifecycleCache,
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Register the lifecycle chaincode cache as a resource so that extensions may have access to it.

closes #244
