### PR TITLE
fix: CouchDB indexes not created for in-process user chaincode

### DIFF
--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
@@ -22,6 +22,8 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/stateleveldb"
 	"github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/hyperledger/fabric/extensions/chaincode/api"
+	"github.com/hyperledger/fabric/extensions/roles"
 	"github.com/pkg/errors"
 )
 
@@ -338,6 +340,60 @@ func (s *DB) HandleChaincodeDeploy(chaincodeDefinition *cceventmgmt.ChaincodeDef
 			}
 		}
 	}
+	return nil
+}
+
+// HandleInProcChaincodeDeploy adds DB indexes for the chaincode
+func (s *DB) HandleInProcChaincodeDeploy(chaincodeDefinition *cceventmgmt.ChaincodeDefinition, artifacts map[string]*api.DBArtifacts) error {
+	if !roles.IsCommitter() {
+		logger.Debugf("Not processing indexes for chaincode [%s] since this peer does not have the 'committer' role", chaincodeDefinition.Name)
+		return nil
+	}
+
+	//Check to see if the interface for IndexCapable is implemented
+	indexCapable, ok := s.VersionedDB.(statedb.IndexCapable)
+	if !ok {
+		return nil
+	}
+
+	if chaincodeDefinition == nil {
+		return errors.New("chaincode definition not found while creating couchdb index")
+	}
+
+	dbArtifacts, ok := artifacts[indexCapable.GetDBType()]
+	if !ok {
+		logger.Debugf("No index definitions for DB of type [%s] for chaincode [%s]", indexCapable.GetDBType(), chaincodeDefinition.Name)
+		return nil
+	}
+
+	collectionConfigMap, err := extractCollectionNames(chaincodeDefinition)
+	if err != nil {
+		logger.Errorf("Error while retrieving collection config for chaincode=[%s]: %s",
+			chaincodeDefinition.Name, err)
+		return nil
+	}
+
+	logger.Debugf("Adding %d index(es) for chaincode [%s]", len(dbArtifacts.Indexes), chaincodeDefinition.Name)
+	if err := indexCapable.ProcessIndexes(chaincodeDefinition.Name, dbArtifacts.Indexes); err != nil {
+		logger.Errorf("Error processing index for chaincode [%s]: %s", chaincodeDefinition.Name, err)
+		return errors.Errorf("Error processing index for chaincode [%s]: %s", chaincodeDefinition.Name, err)
+	}
+
+	for collectionName, collectionIndexes := range dbArtifacts.CollectionIndexes {
+		// check for the dbArtifacts directory for the collection
+		_, ok := collectionConfigMap[collectionName]
+		if !ok {
+			logger.Errorf("Error processing index for chaincode [%s]: cannot create an index for an undefined collection=[%s]", chaincodeDefinition.Name, collectionName)
+			return errors.Errorf("Error processing index for chaincode [%s]: cannot create an index for an undefined collection=[%s]", chaincodeDefinition.Name, collectionName)
+		}
+
+		logger.Debugf("Adding %d index(es) for collection [%s] in chaincode [%s]", len(collectionIndexes), collectionName, chaincodeDefinition.Name)
+		if err := indexCapable.ProcessIndexes(derivePvtDataNs(chaincodeDefinition.Name, collectionName), collectionIndexes); err != nil {
+			logger.Errorf("Error processing collection index for chaincode [%s]: %s", chaincodeDefinition.Name, err)
+			return errors.Errorf("Error processing collection index for chaincode [%s]: %s", chaincodeDefinition.Name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/core/ledger/kvledger/txmgmt/statedb/statedb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statedb.go
@@ -106,6 +106,7 @@ type BulkOptimizable interface {
 type IndexCapable interface {
 	GetDBType() string
 	ProcessIndexesForChaincodeDeploy(namespace string, indexFilesData map[string][]byte) error
+	ProcessIndexes(namespace string, entries []string) error
 }
 
 // FullScanIterator provides a mean to iterate over entire statedb. The intended use of this iterator


### PR DESCRIPTION
This code was left out in the Fabric 2.2 merge.

closes #248
