### PR TITLE
fix: Strip minor version from ID when launching in-process user chaincode

### DIFF
--- a/core/chaincode/lifecycle/cache.go
+++ b/core/chaincode/lifecycle/cache.go
@@ -151,17 +151,17 @@ func (c *Cache) InitializeLocalChaincodes() error {
 	}
 
 	for _, cc := range extchaincode.Chaincodes() {
-		logger.Debugf("Adding in-process chaincode [%s]", extchaincode.GetID(cc))
+		logger.Debugf("Adding in-process chaincode [%s]", extchaincode.GetPackageID(cc))
 
 		ccPackages = append(ccPackages, chaincode.InstalledChaincode{
-			PackageID: extchaincode.GetID(cc),
+			PackageID: extchaincode.GetPackageID(cc),
 			Label:     cc.Name(),
 		})
 	}
 
 	for _, ccPackage := range ccPackages {
 		var parsedCCPackage *persistence.ChaincodePackage
-		if cc, ok := extchaincode.GetUCCByID(ccPackage.PackageID); ok {
+		if cc, ok := extchaincode.GetUCCByPackageID(ccPackage.PackageID); ok {
 			parsedCCPackage = &persistence.ChaincodePackage{
 				Metadata: &persistence.ChaincodePackageMetadata{
 					Type:  "golang",

--- a/core/chaincode/lifecycle/custodian.go
+++ b/core/chaincode/lifecycle/custodian.go
@@ -101,7 +101,7 @@ func (cc *ChaincodeCustodian) Work(buildRegistry *container.BuildRegistry, build
 		cc.choreQueue = cc.choreQueue[1:]
 		cc.mutex.Unlock()
 
-		_, isCCInProcess := extchaincode.GetUCCByID(chore.chaincodeID)
+		_, isCCInProcess := extchaincode.GetUCCByPackageID(chore.chaincodeID)
 
 		if chore.runnable {
 			if isCCInProcess {

--- a/core/chaincode/lifecycle/event_broker.go
+++ b/core/chaincode/lifecycle/event_broker.go
@@ -48,7 +48,7 @@ func (b *EventBroker) ProcessInstallEvent(localChaincode *LocalChaincode) {
 
 	var dbArtifacts []byte
 
-	if _, ok := extchaincode.GetUCCByID(localChaincode.Info.PackageID); ok {
+	if _, ok := extchaincode.GetUCCByPackageID(localChaincode.Info.PackageID); ok {
 		logger.Debugf("Not loading DB artifacts for in-process user chaincode [%s]", localChaincode.Info.PackageID)
 	} else {
 		var err error
@@ -101,7 +101,7 @@ func (b *EventBroker) ProcessApproveOrDefineEvent(channelID string, chaincodeNam
 
 	var dbArtifacts []byte
 
-	if _, ok := extchaincode.GetUCCByID(cachedChaincode.InstallInfo.PackageID); ok {
+	if _, ok := extchaincode.GetUCCByPackageID(cachedChaincode.InstallInfo.PackageID); ok {
 		logger.Debugf("[%s] Not loading DB artifacts for in-process user chaincode [%s]", channelID, cachedChaincode.InstallInfo.PackageID)
 	} else {
 		var err error

--- a/extensions/chaincode/ucc.go
+++ b/extensions/chaincode/ucc.go
@@ -15,8 +15,8 @@ func GetUCC(name, version string) (api.UserCC, bool) {
 	return nil, false
 }
 
-// GetUCCByID returns the in-process user chaincode for the given ID
-func GetUCCByID(string) (api.UserCC, bool) {
+// GetUCCByPackageID returns the in-process user chaincode for the given package ID
+func GetUCCByPackageID(string) (api.UserCC, bool) {
 	return nil, false
 }
 
@@ -29,7 +29,7 @@ func Chaincodes() []api.UserCC {
 func WaitForReady() {
 }
 
-// GetID returns the ID of the chaincode which includes the name and version
-func GetID(cc api.UserCC) string {
+// GetPackageID returns the package ID of the chaincode
+func GetPackageID(cc api.UserCC) string {
 	return cc.Name() + ":" + cc.Version()
 }

--- a/extensions/chaincode/ucc_test.go
+++ b/extensions/chaincode/ucc_test.go
@@ -29,7 +29,7 @@ func TestWaitForReady(t *testing.T) {
 	require.NotPanics(t, WaitForReady)
 }
 
-func TestGetID(t *testing.T) {
+func TestGetPackageID(t *testing.T) {
 	const cc1 = "cc1"
 	const v1 = "v1"
 
@@ -37,6 +37,6 @@ func TestGetID(t *testing.T) {
 	cc.NameReturns(cc1)
 	cc.VersionReturns(v1)
 
-	ccid := GetID(cc)
+	ccid := GetPackageID(cc)
 	require.Equal(t, "cc1:v1", ccid)
 }

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -818,7 +818,7 @@ func serve(args []string) error {
 				installedCCs = append(installedCCs, ccs...)
 
 				for _, cc := range extchaincode.Chaincodes() {
-					logger.Infof("... adding in-process chaincode [%s]", extchaincode.GetID(cc))
+					logger.Infof("... adding in-process chaincode [%s]", extchaincode.GetPackageID(cc))
 					installedCCs = append(installedCCs, ccdef.InstalledChaincode{
 						Name:    cc.Name(),
 						Version: cc.Version(),


### PR DESCRIPTION
For legacy chaincode, the ID of the chaincode was also including a minor version. This fix strips the minor version of the ID and uses this ID when registering handlers.

closes #251
