### PR TITLE
feat: Register a query executor provider along with state DB

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -437,6 +437,11 @@ func (l *kvLedger) NewQueryExecutor() (ledger.QueryExecutor, error) {
 	return l.txmgr.NewQueryExecutor(util.GenerateUUID())
 }
 
+// NewQueryExecutorNoLock returns a query executor without acquiring a commit read lock
+func (l *kvLedger) NewQueryExecutorNoLock() (ledger.QueryExecutor, error) {
+	return l.txmgr.NewQueryExecutorNoLock(util.GenerateUUID())
+}
+
 // NewHistoryQueryExecutor gives handle to a history query executor.
 // A client can obtain more than one 'HistoryQueryExecutor's for parallel execution.
 // Any synchronization should be performed at the implementation level if required

--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -399,7 +399,7 @@ func (p *Provider) open(ledgerID string) (ledger.PeerLedger, error) {
 		return nil, err
 	}
 
-	extstatedb.Register(ledgerID, db)
+	extstatedb.Register(ledgerID, db, l)
 
 	return l, nil
 }

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbased_txmgr.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbased_txmgr.go
@@ -152,6 +152,11 @@ func (txmgr *LockBasedTxMgr) NewQueryExecutor(txid string) (ledger.QueryExecutor
 	return qe, nil
 }
 
+// NewQueryExecutorNoLock returns a query executor without acquiring a commit read lock
+func (txmgr *LockBasedTxMgr) NewQueryExecutorNoLock(txid string) (ledger.QueryExecutor, error) {
+	return newQueryExecutor(txmgr, txid, nil, true, txmgr.hashFunc), nil
+}
+
 // NewQueryExecutorNoCollChecks is a workaround to make the initilization of lifecycle cache
 // work. The issue is that in the current lifecycle code the cache is initialized via Initialize
 // function of a statelistener which gets invoked during ledger opening. This invovation eventually

--- a/extensions/storage/statedb/statedb.go
+++ b/extensions/storage/statedb/statedb.go
@@ -7,9 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package statedb
 
 import (
+	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 )
+
+// QueryExecutorProvider provides a query executor with and without a commit lock
+type QueryExecutorProvider interface {
+	NewQueryExecutor() (ledger.QueryExecutor, error)
+	NewQueryExecutorNoLock() (ledger.QueryExecutor, error)
+}
 
 //AddCCUpgradeHandler adds chaincode upgrade handler to blockpublisher
 func AddCCUpgradeHandler(chainName string, handler gossipapi.ChaincodeUpgradeHandler) {
@@ -17,6 +24,6 @@ func AddCCUpgradeHandler(chainName string, handler gossipapi.ChaincodeUpgradeHan
 }
 
 // Register registers a state database for a given channel
-func Register(channelID string, db statedb.VersionedDB) {
+func Register(channelID string, db statedb.VersionedDB, qep QueryExecutorProvider) {
 	// do nothing
 }

--- a/integration/helpers/images.go
+++ b/integration/helpers/images.go
@@ -23,7 +23,7 @@ func AssertImagesExist(imageNames ...string) {
 
 	for _, imageName := range imageNames {
 		images, err := dockerClient.ListImages(docker.ListImagesOptions{
-			Filter: imageName,
+			Filters: map[string][]string{"reference": {imageName}},
 		})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
When a channel is created then, along with registering a state database, a query executor provider is also registered. The query executor provider returns query executors with and without a ledger lock. In some cases (such as with off-ledger and transient data) a ledger lock is not required and this will improve performance when reading data.

closes #291
